### PR TITLE
fix(build): add camera files to Xcode project

### DIFF
--- a/AudioPriorityBar.xcodeproj/project.pbxproj
+++ b/AudioPriorityBar.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		A10000000000000000000004 /* PriorityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* PriorityManager.swift */; };
 		A10000000000000000000005 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* MenuBarView.swift */; };
 		A10000000000000000000006 /* DeviceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* DeviceListView.swift */; };
+		A10000000000000000000007 /* CameraDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000008 /* CameraDevice.swift */; };
+		A10000000000000000000008 /* CameraDeviceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000009 /* CameraDeviceService.swift */; };
+		A10000000000000000000009 /* CameraListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000A /* CameraListView.swift */; };
 		A10000000000000000000010 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* CoreAudio.framework */; };
 		A10000000000000000000020 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000020 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -25,6 +28,9 @@
 		A20000000000000000000005 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		A20000000000000000000006 /* DeviceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceListView.swift; sourceTree = "<group>"; };
 		A20000000000000000000007 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A20000000000000000000008 /* CameraDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraDevice.swift; sourceTree = "<group>"; };
+		A20000000000000000000009 /* CameraDeviceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraDeviceService.swift; sourceTree = "<group>"; };
+		A2000000000000000000000A /* CameraListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraListView.swift; sourceTree = "<group>"; };
 		A20000000000000000000010 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		A20000000000000000000020 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A30000000000000000000001 /* AudioPriorityBar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AudioPriorityBar.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -68,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000000000000000000002 /* AudioDevice.swift */,
+				A20000000000000000000008 /* CameraDevice.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -76,6 +83,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000000000000000000003 /* AudioDeviceService.swift */,
+				A20000000000000000000009 /* CameraDeviceService.swift */,
 				A20000000000000000000004 /* PriorityManager.swift */,
 			);
 			path = Services;
@@ -86,6 +94,7 @@
 			children = (
 				A20000000000000000000005 /* MenuBarView.swift */,
 				A20000000000000000000006 /* DeviceListView.swift */,
+				A2000000000000000000000A /* CameraListView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -177,10 +186,13 @@
 			files = (
 				A10000000000000000000001 /* AudioPriorityBarApp.swift in Sources */,
 				A10000000000000000000002 /* AudioDevice.swift in Sources */,
+				A10000000000000000000007 /* CameraDevice.swift in Sources */,
 				A10000000000000000000003 /* AudioDeviceService.swift in Sources */,
+				A10000000000000000000008 /* CameraDeviceService.swift in Sources */,
 				A10000000000000000000004 /* PriorityManager.swift in Sources */,
 				A10000000000000000000005 /* MenuBarView.swift in Sources */,
 				A10000000000000000000006 /* DeviceListView.swift in Sources */,
+				A10000000000000000000009 /* CameraListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

The camera Swift files were added to disk but not registered in the Xcode project, causing build failures:

- `CameraDevice.swift`, `CameraDeviceService.swift`, and `CameraListView.swift` exist on disk
- They were missing from `project.pbxproj` (no PBXBuildFile, PBXFileReference, or PBXSourcesBuildPhase entries)
- Result: `cannot find type 'CameraDevice' in scope` and similar errors

This PR adds the missing file references to the Xcode project configuration.

## Test plan

- [x] `./build.sh` now succeeds