### PR TITLE
Launch at Login: Add toggle to start app automatically on login

### DIFF
--- a/AudioPriorityBar.xcodeproj/project.pbxproj
+++ b/AudioPriorityBar.xcodeproj/project.pbxproj
@@ -331,7 +331,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.AudioPriorityBar;
+				PRODUCT_BUNDLE_IDENTIFIER = app.audioprioritybar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -360,7 +360,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.AudioPriorityBar;
+				PRODUCT_BUNDLE_IDENTIFIER = app.audioprioritybar;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/AudioPriorityBar.xcodeproj/project.pbxproj
+++ b/AudioPriorityBar.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		A10000000000000000000004 /* PriorityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* PriorityManager.swift */; };
 		A10000000000000000000005 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* MenuBarView.swift */; };
 		A10000000000000000000006 /* DeviceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* DeviceListView.swift */; };
+		A10000000000000000000007 /* LaunchAtLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000008 /* LaunchAtLoginManager.swift */; };
 		A10000000000000000000010 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* CoreAudio.framework */; };
 		A10000000000000000000020 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000020 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -25,6 +26,7 @@
 		A20000000000000000000005 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		A20000000000000000000006 /* DeviceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceListView.swift; sourceTree = "<group>"; };
 		A20000000000000000000007 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A20000000000000000000008 /* LaunchAtLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginManager.swift; sourceTree = "<group>"; };
 		A20000000000000000000010 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		A20000000000000000000020 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A30000000000000000000001 /* AudioPriorityBar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AudioPriorityBar.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,6 +79,7 @@
 			children = (
 				A20000000000000000000003 /* AudioDeviceService.swift */,
 				A20000000000000000000004 /* PriorityManager.swift */,
+				A20000000000000000000008 /* LaunchAtLoginManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -181,6 +184,7 @@
 				A10000000000000000000004 /* PriorityManager.swift in Sources */,
 				A10000000000000000000005 /* MenuBarView.swift in Sources */,
 				A10000000000000000000006 /* DeviceListView.swift in Sources */,
+				A10000000000000000000007 /* LaunchAtLoginManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AudioPriorityBar/Services/LaunchAtLoginManager.swift
+++ b/AudioPriorityBar/Services/LaunchAtLoginManager.swift
@@ -1,0 +1,61 @@
+import Foundation
+import ServiceManagement
+
+@MainActor
+class LaunchAtLoginManager: ObservableObject {
+    static let shared = LaunchAtLoginManager()
+    
+    @Published var isEnabled: Bool {
+        didSet {
+            if isEnabled {
+                enableLaunchAtLogin()
+            } else {
+                disableLaunchAtLogin()
+            }
+        }
+    }
+    
+    private init() {
+        // Check current status
+        if #available(macOS 13.0, *) {
+            isEnabled = SMAppService.mainApp.status == .enabled
+        } else {
+            isEnabled = false
+        }
+    }
+    
+    private func enableLaunchAtLogin() {
+        if #available(macOS 13.0, *) {
+            do {
+                try SMAppService.mainApp.register()
+            } catch {
+                print("Failed to enable launch at login: \(error)")
+                // Revert the toggle if registration fails
+                DispatchQueue.main.async {
+                    self.isEnabled = false
+                }
+            }
+        }
+    }
+    
+    private func disableLaunchAtLogin() {
+        if #available(macOS 13.0, *) {
+            do {
+                try SMAppService.mainApp.unregister()
+            } catch {
+                print("Failed to disable launch at login: \(error)")
+            }
+        }
+    }
+    
+    func refresh() {
+        if #available(macOS 13.0, *) {
+            let newStatus = SMAppService.mainApp.status == .enabled
+            if newStatus != isEnabled {
+                // Update without triggering didSet
+                _isEnabled = Published(wrappedValue: newStatus)
+            }
+        }
+    }
+}
+

--- a/AudioPriorityBar/Views/MenuBarView.swift
+++ b/AudioPriorityBar/Views/MenuBarView.swift
@@ -91,6 +91,9 @@ struct MenuBarView: View {
                 }
 
                 Spacer()
+                
+                // Launch at login toggle
+                LaunchAtLoginToggle()
 
                 // Edit mode toggle
                 Button {
@@ -410,5 +413,27 @@ struct HiddenDeviceRow: View {
         .onHover { hovering in
             isHovering = hovering
         }
+    }
+}
+
+struct LaunchAtLoginToggle: View {
+    @StateObject private var launchManager = LaunchAtLoginManager.shared
+    
+    var body: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                launchManager.isEnabled.toggle()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: launchManager.isEnabled ? "power.circle.fill" : "power.circle")
+                    .font(.system(size: 12))
+                Text("Login")
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundColor(launchManager.isEnabled ? .accentColor : .secondary)
+        }
+        .buttonStyle(.plain)
+        .help(launchManager.isEnabled ? "Disable launch at login" : "Enable launch at login")
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a Launch at Login toggle, allowing users to have the app start automatically when they log in.

## Changes
- **Launch at Login toggle**: Added power icon button in the footer
- **SMAppService integration**: Uses the modern macOS 13+ API for login item management
- **Visual feedback**: Icon indicates enabled/disabled state
- **Bundle ID update**: Changed to `app.audioprioritybar`

## Implementation
Uses `SMAppService.mainApp` which is the recommended approach for macOS 13+:
- No helper app required
- Managed through System Settings → General → Login Items
- Persists across app updates

## UI Location
The toggle appears in the footer bar, between the hidden devices toggle and the Edit button.

## Testing
- [x] Toggle enables launch at login
- [x] Toggle disables launch at login
- [x] State persists after app restart
- [x] Visible in System Settings → Login Items
- [x] Builds successfully