### PR TITLE
Fix Icon Switching, System Alert Device, Add Priority Overrides per Speaker/Headphone, and Add Fast Switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ Index/
 # xcode-build-server files
 buildServer.json
 .compile
+.claude

--- a/AudioPriorityBar.xcodeproj/project.pbxproj
+++ b/AudioPriorityBar.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4DD6D82E5CF6D899F9B4F327 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622640DCAA11DD5022FC5DBF /* AppInfo.swift */; };
 		5EACF86E108BAB90FAC19892 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE42A89AB153F7394DACCC1B /* PreferencesWindowController.swift */; };
 		ED800EC86195D082D84E8604 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3538E8C4D0E18A321A5344 /* PreferencesView.swift */; };
+		A10000000000000000000012 /* ClickActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000012 /* ClickActions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		622640DCAA11DD5022FC5DBF /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		DE42A89AB153F7394DACCC1B /* PreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
 		BA3538E8C4D0E18A321A5344 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
+		A20000000000000000000012 /* ClickActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickActions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 				A20000000000000000000002 /* AudioDevice.swift */,
 				A20000000000000000000009 /* Headphones.swift */,
 				622640DCAA11DD5022FC5DBF /* AppInfo.swift */,
+				A20000000000000000000012 /* ClickActions.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -197,6 +200,7 @@
 				A10000000000000000000002 /* AudioDevice.swift in Sources */,
 				A10000000000000000000009 /* Headphones.swift in Sources */,
 				4DD6D82E5CF6D899F9B4F327 /* AppInfo.swift in Sources */,
+				A10000000000000000000012 /* ClickActions.swift in Sources */,
 				A10000000000000000000003 /* AudioDeviceService.swift in Sources */,
 				A10000000000000000000004 /* PriorityManager.swift in Sources */,
 				5EACF86E108BAB90FAC19892 /* PreferencesWindowController.swift in Sources */,

--- a/AudioPriorityBar.xcodeproj/project.pbxproj
+++ b/AudioPriorityBar.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A10000000000000000000002 /* AudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* AudioDevice.swift */; };
 		A10000000000000000000003 /* AudioDeviceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000003 /* AudioDeviceService.swift */; };
 		A10000000000000000000004 /* PriorityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* PriorityManager.swift */; };
+		A10000000000000000000011 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000011 /* MenuBarController.swift */; };
 		A10000000000000000000005 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* MenuBarView.swift */; };
 		A10000000000000000000006 /* DeviceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* DeviceListView.swift */; };
 		A10000000000000000000007 /* LaunchAtLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000008 /* LaunchAtLoginManager.swift */; };
@@ -27,6 +28,7 @@
 		A20000000000000000000002 /* AudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevice.swift; sourceTree = "<group>"; };
 		A20000000000000000000003 /* AudioDeviceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceService.swift; sourceTree = "<group>"; };
 		A20000000000000000000004 /* PriorityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriorityManager.swift; sourceTree = "<group>"; };
+		A20000000000000000000011 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		A20000000000000000000005 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		A20000000000000000000006 /* DeviceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceListView.swift; sourceTree = "<group>"; };
 		A20000000000000000000007 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 				A20000000000000000000004 /* PriorityManager.swift */,
 				A20000000000000000000008 /* LaunchAtLoginManager.swift */,
 				DE42A89AB153F7394DACCC1B /* PreferencesWindowController.swift */,
+				A20000000000000000000011 /* MenuBarController.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -201,6 +204,7 @@
 				A10000000000000000000006 /* DeviceListView.swift in Sources */,
 				ED800EC86195D082D84E8604 /* PreferencesView.swift in Sources */,
 				A10000000000000000000007 /* LaunchAtLoginManager.swift in Sources */,
+				A10000000000000000000011 /* MenuBarController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AudioPriorityBar.xcodeproj/project.pbxproj
+++ b/AudioPriorityBar.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		A10000000000000000000009 /* Headphones.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000009 /* Headphones.swift */; };
 		A10000000000000000000010 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* CoreAudio.framework */; };
 		A10000000000000000000020 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000020 /* Assets.xcassets */; };
+		4DD6D82E5CF6D899F9B4F327 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622640DCAA11DD5022FC5DBF /* AppInfo.swift */; };
+		5EACF86E108BAB90FAC19892 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE42A89AB153F7394DACCC1B /* PreferencesWindowController.swift */; };
+		ED800EC86195D082D84E8604 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3538E8C4D0E18A321A5344 /* PreferencesView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +35,9 @@
 		A20000000000000000000010 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		A20000000000000000000020 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A30000000000000000000001 /* AudioPriorityBar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AudioPriorityBar.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		622640DCAA11DD5022FC5DBF /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
+		DE42A89AB153F7394DACCC1B /* PreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
+		BA3538E8C4D0E18A321A5344 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +79,7 @@
 			children = (
 				A20000000000000000000002 /* AudioDevice.swift */,
 				A20000000000000000000009 /* Headphones.swift */,
+				622640DCAA11DD5022FC5DBF /* AppInfo.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -83,6 +90,7 @@
 				A20000000000000000000003 /* AudioDeviceService.swift */,
 				A20000000000000000000004 /* PriorityManager.swift */,
 				A20000000000000000000008 /* LaunchAtLoginManager.swift */,
+				DE42A89AB153F7394DACCC1B /* PreferencesWindowController.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -92,6 +100,7 @@
 			children = (
 				A20000000000000000000005 /* MenuBarView.swift */,
 				A20000000000000000000006 /* DeviceListView.swift */,
+				BA3538E8C4D0E18A321A5344 /* PreferencesView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -184,10 +193,13 @@
 				A10000000000000000000001 /* AudioPriorityBarApp.swift in Sources */,
 				A10000000000000000000002 /* AudioDevice.swift in Sources */,
 				A10000000000000000000009 /* Headphones.swift in Sources */,
+				4DD6D82E5CF6D899F9B4F327 /* AppInfo.swift in Sources */,
 				A10000000000000000000003 /* AudioDeviceService.swift in Sources */,
 				A10000000000000000000004 /* PriorityManager.swift in Sources */,
+				5EACF86E108BAB90FAC19892 /* PreferencesWindowController.swift in Sources */,
 				A10000000000000000000005 /* MenuBarView.swift in Sources */,
 				A10000000000000000000006 /* DeviceListView.swift in Sources */,
+				ED800EC86195D082D84E8604 /* PreferencesView.swift in Sources */,
 				A10000000000000000000007 /* LaunchAtLoginManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AudioPriorityBar/AudioPriorityBarApp.swift
+++ b/AudioPriorityBar/AudioPriorityBarApp.swift
@@ -10,7 +10,14 @@ struct AudioPriorityBarApp: App {
             MenuBarView()
                 .environmentObject(audioManager)
         } label: {
-            Image(systemName: "speaker.wave.2.fill")
+            MenuBarLabel(
+                volume: audioManager.volume,
+                isOutputMuted: audioManager.isActiveOutputMuted,
+                isInputMuted: audioManager.isActiveInputMuted,
+                isCustomMode: audioManager.isCustomMode,
+                mode: audioManager.currentMode,
+                micFlash: audioManager.micFlashState
+            )
         }
         .menuBarExtraStyle(.window)
     }

--- a/AudioPriorityBar/AudioPriorityBarApp.swift
+++ b/AudioPriorityBar/AudioPriorityBarApp.swift
@@ -4,23 +4,163 @@ import OSLog
 
 @main
 struct AudioPriorityBarApp: App {
-    @StateObject private var audioManager = AudioManager()
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
-        MenuBarExtra {
-            MenuBarView()
-                .environmentObject(audioManager)
-        } label: {
-            MenuBarLabel(
-                volume: audioManager.volume,
-                isOutputMuted: audioManager.isActiveOutputMuted,
-                isInputMuted: audioManager.isActiveInputMuted,
-                isCustomMode: audioManager.isCustomMode,
-                mode: audioManager.currentMode,
-                micFlash: audioManager.micFlashState
-            )
+        // Return an empty scene - menu bar is handled by AppDelegate
+        Settings {
+            EmptyView()
         }
-        .menuBarExtraStyle(.window)
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var audioManager: AudioManager!
+    var menuBarController: MenuBarController?
+    var statusItem: NSStatusItem?
+    var popover: NSPopover?
+    
+    @MainActor
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Hide the app from the Dock
+        NSApp.setActivationPolicy(.accessory)
+        
+        // Initialize audio manager
+        audioManager = AudioManager()
+        
+        // Setup menu bar based on preference
+        if audioManager.priorityManager.isQuickSwitchEnabled {
+            setupQuickSwitchMode()
+        } else {
+            setupNormalMode()
+        }
+    }
+    
+    @MainActor
+    private func setupQuickSwitchMode() {
+        menuBarController = MenuBarController(
+            audioManager: audioManager,
+            isQuickSwitchEnabled: true
+        )
+    }
+    
+    @MainActor
+    private func setupNormalMode() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        
+        if let button = statusItem?.button {
+            button.action = #selector(togglePopover(_:))
+            button.target = self
+            updateMenuBarIcon()
+        }
+        
+        // Create popover
+        let popover = NSPopover()
+        popover.contentViewController = NSHostingController(
+            rootView: MenuBarView()
+                .environmentObject(audioManager)
+        )
+        popover.behavior = .transient
+        self.popover = popover
+        
+        // Observe changes to update the menu bar icon
+        setupObservers()
+    }
+    
+    @objc private func togglePopover(_ sender: AnyObject?) {
+        guard let popover = popover else { return }
+        
+        if popover.isShown {
+            popover.performClose(sender)
+        } else if let button = statusItem?.button {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            NSApp.activate(ignoringOtherApps: true)
+            popover.contentViewController?.view.window?.makeKey()
+        }
+    }
+    
+    @MainActor
+    private func updateMenuBarIcon() {
+        guard let button = statusItem?.button else { return }
+        
+        // Build icon using SF Symbols based on state
+        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .regular)
+        var symbols: [NSImage] = []
+        
+        // Input mute indicator
+        if audioManager.isActiveInputMuted {
+            let micIcon = audioManager.micFlashState ? "mic.fill" : "mic.slash.fill"
+            if let image = NSImage(systemSymbolName: micIcon, accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        }
+        
+        // Custom mode indicator
+        if audioManager.isCustomMode {
+            if let image = NSImage(systemSymbolName: "hand.raised.fill", accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        }
+        
+        // Output indicator - headphone in headphone mode, speaker in speaker mode
+        if audioManager.currentMode == .headphone {
+            // Headphone icon
+            if let image = NSImage(systemSymbolName: "headphones", accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        } else {
+            // Speaker icon with volume indication
+            let speakerIcon: String
+            if audioManager.isActiveOutputMuted {
+                speakerIcon = "speaker.slash.fill"
+            } else {
+                // Use variable speaker icon based on volume
+                let volume = audioManager.volume
+                if volume > 0.66 {
+                    speakerIcon = "speaker.wave.3.fill"
+                } else if volume > 0.33 {
+                    speakerIcon = "speaker.wave.2.fill"
+                } else if volume > 0 {
+                    speakerIcon = "speaker.wave.1.fill"
+                } else {
+                    speakerIcon = "speaker.fill"
+                }
+            }
+            
+            if let image = NSImage(systemSymbolName: speakerIcon, accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        }
+        
+        // Combine symbols into one image
+        if !symbols.isEmpty {
+            let spacing: CGFloat = 2
+            let totalWidth = symbols.map { $0.size.width }.reduce(0, +) + CGFloat(symbols.count - 1) * spacing
+            let maxHeight = symbols.map { $0.size.height }.max() ?? 16
+            
+            let combinedImage = NSImage(size: NSSize(width: totalWidth, height: maxHeight))
+            combinedImage.lockFocus()
+            
+            var xOffset: CGFloat = 0
+            for symbol in symbols {
+                let yOffset = (maxHeight - symbol.size.height) / 2
+                symbol.draw(at: NSPoint(x: xOffset, y: yOffset), from: .zero, operation: .sourceOver, fraction: 1.0)
+                xOffset += symbol.size.width + spacing
+            }
+            
+            combinedImage.unlockFocus()
+            combinedImage.isTemplate = true
+            button.image = combinedImage
+        }
+    }
+    
+    private func setupObservers() {
+        // Observe audio manager properties to update menu bar icon
+        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateMenuBarIcon()
+            }
+        }
     }
 }
 

--- a/AudioPriorityBar/AudioPriorityBarApp.swift
+++ b/AudioPriorityBar/AudioPriorityBarApp.swift
@@ -4,7 +4,7 @@ import CoreAudio
 @main
 struct AudioPriorityBarApp: App {
     @StateObject private var audioManager = AudioManager()
-    
+
     var body: some Scene {
         MenuBarExtra {
             MenuBarView()

--- a/AudioPriorityBar/AudioPriorityBarApp.swift
+++ b/AudioPriorityBar/AudioPriorityBarApp.swift
@@ -579,7 +579,7 @@ class AudioManager: ObservableObject {
             return
         }
 
-        deviceService.setDefaultDevice(device.id, type: .output)
+        deviceService.setDefaultDevice(device.id, type: .output, syncSystemOutput: priorityManager.syncSystemOutput)
         currentOutputId = device.id
         logger.debug("  ✅ Output device set")
 

--- a/AudioPriorityBar/AudioPriorityBarApp.swift
+++ b/AudioPriorityBar/AudioPriorityBarApp.swift
@@ -107,6 +107,7 @@ class AudioManager: ObservableObject {
     private var micFlashTimer: Timer?
     let priorityManager = PriorityManager()
     private var connectedDeviceUIDs: Set<String> = []
+    private var volumeSetTask: Task<Void, Never>?
 
     private let logger = Logger(subsystem: "com.audioprioritybar", category: "AudioManager")
     private var handleDeviceChangeCount = 0
@@ -168,6 +169,20 @@ class AudioManager: ObservableObject {
 
     func setVolume(_ newVolume: Float) {
         volume = newVolume
+
+        // Suppress system-callback volume refresh while the user is actively controlling volume.
+        // Without this, the CoreAudio listener fires handleMuteOrVolumeChange → refreshVolume()
+        // which reads a lagging hardware value and snaps the UI back, causing jitter.
+        volumeSetTask?.cancel()
+        volumeSetTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: 100_000_000) // 100ms debounce
+                self.volumeSetTask = nil
+            } catch {
+                // Cancelled because setVolume was called again — keep suppressing
+            }
+        }
+
         deviceService.setOutputVolume(newVolume)
 
         // Unmute the device if it's muted and volume is being changed
@@ -222,7 +237,10 @@ class AudioManager: ObservableObject {
 
     private func handleMuteOrVolumeChange() {
         refreshMuteStatus()
-        refreshVolume()
+        // Only sync volume from the system when the user isn't actively setting it
+        if volumeSetTask == nil {
+            refreshVolume()
+        }
     }
 
     func refreshDevices() {
@@ -303,17 +321,20 @@ class AudioManager: ObservableObject {
         }
     }
 
-    func toggleMode() {
+    /// Returns true if the toggle succeeded, false if there was nothing to switch to.
+    @discardableResult
+    func toggleMode() -> Bool {
         let newMode: OutputCategory = currentMode == .speaker ? .headphone : .speaker
 
         // Check if target mode has any connected devices
         let targetDevices = newMode == .speaker ? speakerDevices : headphoneDevices
         let hasConnectedDevices = targetDevices.contains { $0.isConnected }
 
-        // Only switch if target mode has connected devices
         if hasConnectedDevices {
             setMode(newMode)
+            return true
         }
+        return false
     }
 
     func setCustomMode(_ enabled: Bool) {

--- a/AudioPriorityBar/Models/AppInfo.swift
+++ b/AudioPriorityBar/Models/AppInfo.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Utility struct to access app version and build information
+struct AppInfo {
+    /// The short version string (e.g., "1.0.0")
+    static var version: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+    }
+
+    /// The build number (e.g., "42")
+    static var build: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "1"
+    }
+
+    /// Combined version and build string (e.g., "Version 1.0.0 (42)")
+    static var versionString: String {
+        "Version \(version) (\(build))"
+    }
+
+    /// App name from bundle
+    static var appName: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Audio Priority Bar"
+    }
+}

--- a/AudioPriorityBar/Models/ClickActions.swift
+++ b/AudioPriorityBar/Models/ClickActions.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Represents an action that can be triggered by clicking the menu bar icon
+enum ClickAction: String, Codable, CaseIterable {
+    case toggle = "Toggle Mode"
+    case menu = "Show Menu"
+    case noAction = "No Action"
+
+    var displayName: String { self.rawValue }
+}
+
+/// Configuration for click actions on the menu bar icon
+struct ClickActionsConfig: Codable {
+    var leftClick: ClickAction
+    var rightClick: ClickAction
+    var longLeftClick: ClickAction
+    var longRightClick: ClickAction
+
+    /// Default configuration: left and right click show menu, long presses do nothing
+    static var `default`: ClickActionsConfig {
+        ClickActionsConfig(
+            leftClick: .menu,
+            rightClick: .menu,
+            longLeftClick: .noAction,
+            longRightClick: .noAction
+        )
+    }
+
+    /// Validates that at least one action is set to show menu
+    var isValid: Bool {
+        leftClick == .menu || rightClick == .menu ||
+        longLeftClick == .menu || longRightClick == .menu
+    }
+}

--- a/AudioPriorityBar/Services/MenuBarController.swift
+++ b/AudioPriorityBar/Services/MenuBarController.swift
@@ -1,0 +1,164 @@
+import AppKit
+import SwiftUI
+
+/// Controls the menu bar item and handles click events
+@MainActor
+class MenuBarController {
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+    private let audioManager: AudioManager
+    private let isQuickSwitchEnabled: Bool
+    private var updateTimer: Timer?
+    
+    init(audioManager: AudioManager, isQuickSwitchEnabled: Bool) {
+        self.audioManager = audioManager
+        self.isQuickSwitchEnabled = isQuickSwitchEnabled
+        setupMenuBar()
+        setupUpdateTimer()
+    }
+    
+    private func setupMenuBar() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        
+        if let button = statusItem?.button {
+            updateButton()
+            
+            if isQuickSwitchEnabled {
+                // Quick switch mode: left click toggles, right click shows menu
+                button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+                button.action = #selector(handleClick(_:))
+                button.target = self
+            } else {
+                // Normal mode: any click shows menu
+                button.action = #selector(handleClick(_:))
+                button.target = self
+            }
+        }
+        
+        // Create popover for menu content
+        let popover = NSPopover()
+        popover.contentViewController = NSHostingController(
+            rootView: MenuBarView()
+                .environmentObject(audioManager)
+        )
+        popover.behavior = .transient
+        self.popover = popover
+    }
+    
+    private func setupUpdateTimer() {
+        // Update the menu bar icon periodically to reflect state changes
+        updateTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateButton()
+            }
+        }
+    }
+    
+    @objc private func handleClick(_ sender: NSStatusBarButton) {
+        guard let event = NSApp.currentEvent else { return }
+        
+        if isQuickSwitchEnabled {
+            if event.type == .rightMouseUp {
+                // Right click: show menu
+                showPopover(sender)
+            } else if event.type == .leftMouseUp {
+                // Left click: toggle mode
+                audioManager.toggleMode()
+                updateButton()
+            }
+        } else {
+            // Normal mode: show menu
+            showPopover(sender)
+        }
+    }
+    
+    private func showPopover(_ sender: NSStatusBarButton) {
+        guard let popover = popover else { return }
+        
+        if popover.isShown {
+            popover.performClose(sender)
+        } else {
+            popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+            NSApp.activate(ignoringOtherApps: true)
+            popover.contentViewController?.view.window?.makeKey()
+        }
+    }
+    
+    func updateButton() {
+        guard let button = statusItem?.button else { return }
+        
+        // Build icon using SF Symbols based on state
+        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .regular)
+        var symbols: [NSImage] = []
+        
+        // Input mute indicator
+        if audioManager.isActiveInputMuted {
+            let micIcon = audioManager.micFlashState ? "mic.fill" : "mic.slash.fill"
+            if let image = NSImage(systemSymbolName: micIcon, accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        }
+        
+        // Custom mode indicator
+        if audioManager.isCustomMode {
+            if let image = NSImage(systemSymbolName: "hand.raised.fill", accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        }
+        
+        // Output indicator - headphone in headphone mode, speaker in speaker mode
+        if audioManager.currentMode == .headphone {
+            // Headphone icon
+            if let image = NSImage(systemSymbolName: "headphones", accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        } else {
+            // Speaker icon with volume indication
+            let speakerIcon: String
+            if audioManager.isActiveOutputMuted {
+                speakerIcon = "speaker.slash.fill"
+            } else {
+                // Use variable speaker icon based on volume
+                let volume = audioManager.volume
+                if volume > 0.66 {
+                    speakerIcon = "speaker.wave.3.fill"
+                } else if volume > 0.33 {
+                    speakerIcon = "speaker.wave.2.fill"
+                } else if volume > 0 {
+                    speakerIcon = "speaker.wave.1.fill"
+                } else {
+                    speakerIcon = "speaker.fill"
+                }
+            }
+            
+            if let image = NSImage(systemSymbolName: speakerIcon, accessibilityDescription: nil)?.withSymbolConfiguration(config) {
+                symbols.append(image)
+            }
+        }
+        
+        // Combine symbols into one image
+        if !symbols.isEmpty {
+            let spacing: CGFloat = 2
+            let totalWidth = symbols.map { $0.size.width }.reduce(0, +) + CGFloat(symbols.count - 1) * spacing
+            let maxHeight = symbols.map { $0.size.height }.max() ?? 16
+            
+            let combinedImage = NSImage(size: NSSize(width: totalWidth, height: maxHeight))
+            combinedImage.lockFocus()
+            
+            var xOffset: CGFloat = 0
+            for symbol in symbols {
+                let yOffset = (maxHeight - symbol.size.height) / 2
+                symbol.draw(at: NSPoint(x: xOffset, y: yOffset), from: .zero, operation: .sourceOver, fraction: 1.0)
+                xOffset += symbol.size.width + spacing
+            }
+            
+            combinedImage.unlockFocus()
+            combinedImage.isTemplate = true
+            button.image = combinedImage
+        }
+    }
+    
+    deinit {
+        updateTimer?.invalidate()
+    }
+}

--- a/AudioPriorityBar/Services/MenuBarController.swift
+++ b/AudioPriorityBar/Services/MenuBarController.swift
@@ -122,8 +122,12 @@ class MenuBarController {
     private func executeAction(_ action: ClickAction, sender: NSStatusBarButton? = nil) {
         switch action {
         case .toggle:
-            audioManager.toggleMode()
-            updateButton()
+            let toggled = audioManager.toggleMode()
+            if toggled {
+                updateButton()
+            } else if let sender = sender {
+                showPopover(sender)
+            }
         case .menu:
             if let sender = sender {
                 showPopover(sender)
@@ -193,7 +197,22 @@ class MenuBarController {
             }
             
             if let image = NSImage(systemSymbolName: speakerIcon, accessibilityDescription: nil)?.withSymbolConfiguration(config) {
-                symbols.append(image)
+                // Pad to the widest possible speaker icon so the slot width never changes
+                let allSpeakerIcons = ["speaker.slash.fill", "speaker.wave.3.fill", "speaker.wave.2.fill", "speaker.wave.1.fill", "speaker.fill"]
+                let maxWidth = allSpeakerIcons.compactMap {
+                    NSImage(systemSymbolName: $0, accessibilityDescription: nil)?.withSymbolConfiguration(config)?.size.width
+                }.max() ?? image.size.width
+
+                if maxWidth > image.size.width {
+                    let padded = NSImage(size: NSSize(width: maxWidth, height: image.size.height))
+                    padded.lockFocus()
+                    image.draw(at: NSPoint(x: (maxWidth - image.size.width) / 2, y: 0), from: .zero, operation: .sourceOver, fraction: 1.0)
+                    padded.unlockFocus()
+                    padded.isTemplate = true
+                    symbols.append(padded)
+                } else {
+                    symbols.append(image)
+                }
             }
         }
         

--- a/AudioPriorityBar/Services/PreferencesWindowController.swift
+++ b/AudioPriorityBar/Services/PreferencesWindowController.swift
@@ -1,0 +1,48 @@
+import AppKit
+import SwiftUI
+
+/// Singleton controller to manage the preferences window lifecycle
+class PreferencesWindowController {
+    /// Shared singleton instance
+    static let shared = PreferencesWindowController()
+
+    /// The preferences window instance
+    private var window: NSWindow?
+
+    /// Private initializer to enforce singleton pattern
+    private init() {}
+
+    /// Shows the preferences window, creating it if needed or bringing it to front if already exists
+    /// - Parameter audioManager: The audio manager to pass to the preferences view
+    func show(audioManager: AudioManager) {
+        if let existingWindow = window {
+            // Window already exists, just bring to front
+            existingWindow.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        } else {
+            // Create new window
+            let preferencesView = PreferencesView()
+                .environmentObject(audioManager)
+
+            let hostingController = NSHostingController(rootView: preferencesView)
+
+            let newWindow = NSWindow(contentViewController: hostingController)
+            newWindow.title = "Audio Priority Bar Preferences"
+            newWindow.styleMask = [.titled, .closable, .miniaturizable]
+            newWindow.setContentSize(NSSize(width: 480, height: 400))
+            newWindow.center()
+            newWindow.level = .floating
+            newWindow.isReleasedWhenClosed = false
+            newWindow.setFrameAutosaveName("PreferencesWindow")
+
+            self.window = newWindow
+            newWindow.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    /// Closes the preferences window
+    func close() {
+        window?.close()
+    }
+}

--- a/AudioPriorityBar/Services/PriorityManager.swift
+++ b/AudioPriorityBar/Services/PriorityManager.swift
@@ -42,6 +42,7 @@ class PriorityManager {
     private let customModeKey = "customMode"
     private let hiddenDevicesKey = "hiddenDevices"
     private let knownDevicesKey = "knownDevices"
+    private let quickSwitchKey = "quickSwitchEnabled"
 
     // MARK: - Known Devices (Persistent Memory)
 
@@ -99,6 +100,11 @@ class PriorityManager {
     var isCustomMode: Bool {
         get { defaults.bool(forKey: customModeKey) }
         set { defaults.set(newValue, forKey: customModeKey) }
+    }
+
+    var isQuickSwitchEnabled: Bool {
+        get { defaults.bool(forKey: quickSwitchKey) }
+        set { defaults.set(newValue, forKey: quickSwitchKey) }
     }
 
     // MARK: - Device Categories

--- a/AudioPriorityBar/Services/PriorityManager.swift
+++ b/AudioPriorityBar/Services/PriorityManager.swift
@@ -148,6 +148,30 @@ class PriorityManager {
     private let hiddenSpeakersKey = "hiddenSpeakers"
     private let hiddenHeadphonesKey = "hiddenHeadphones"
 
+    // MARK: - Preferred Inputs for Outputs
+
+    private let preferredInputsKey = "preferredInputsForOutputs"
+
+    /// Get the preferred input device UID for a given output device
+    func getPreferredInput(forOutput outputUID: String) -> String? {
+        let mappings = defaults.dictionary(forKey: preferredInputsKey) as? [String: String] ?? [:]
+        return mappings[outputUID]
+    }
+
+    /// Set a preferred input device for a given output device
+    func setPreferredInput(_ inputUID: String, forOutput outputUID: String) {
+        var mappings = defaults.dictionary(forKey: preferredInputsKey) as? [String: String] ?? [:]
+        mappings[outputUID] = inputUID
+        defaults.set(mappings, forKey: preferredInputsKey)
+    }
+
+    /// Clear the preferred input for a given output device
+    func clearPreferredInput(forOutput outputUID: String) {
+        var mappings = defaults.dictionary(forKey: preferredInputsKey) as? [String: String] ?? [:]
+        mappings.removeValue(forKey: outputUID)
+        defaults.set(mappings, forKey: preferredInputsKey)
+    }
+
     func isHidden(_ device: AudioDevice) -> Bool {
         let key = hiddenKey(for: device)
         let hidden = defaults.array(forKey: key) as? [String] ?? []

--- a/AudioPriorityBar/Services/PriorityManager.swift
+++ b/AudioPriorityBar/Services/PriorityManager.swift
@@ -43,6 +43,7 @@ class PriorityManager {
     private let hiddenDevicesKey = "hiddenDevices"
     private let knownDevicesKey = "knownDevices"
     private let quickSwitchKey = "quickSwitchEnabled"
+    private let syncSystemOutputKey = "syncSystemOutput"
 
     // MARK: - Known Devices (Persistent Memory)
 
@@ -105,6 +106,17 @@ class PriorityManager {
     var isQuickSwitchEnabled: Bool {
         get { defaults.bool(forKey: quickSwitchKey) }
         set { defaults.set(newValue, forKey: quickSwitchKey) }
+    }
+
+    var syncSystemOutput: Bool {
+        get { 
+            // Default to true if not set
+            if defaults.object(forKey: syncSystemOutputKey) == nil {
+                return true
+            }
+            return defaults.bool(forKey: syncSystemOutputKey)
+        }
+        set { defaults.set(newValue, forKey: syncSystemOutputKey) }
     }
 
     // MARK: - Device Categories

--- a/AudioPriorityBar/Views/DeviceListView.swift
+++ b/AudioPriorityBar/Views/DeviceListView.swift
@@ -281,6 +281,26 @@ struct DraggableDeviceRow: View {
                         }
                     }
 
+                    // Prefer for current output (input devices only)
+                    if device.type == .input && device.isConnected, let currentOutputId = audioManager.currentOutputId,
+                       let currentOutput = (audioManager.speakerDevices + audioManager.headphoneDevices).first(where: { $0.id == currentOutputId }) {
+                        Divider()
+                        let isPreferred = audioManager.getPreferredInputUID(forOutput: currentOutput.uid) == device.uid
+                        Button {
+                            if isPreferred {
+                                audioManager.clearPreferredInput(forOutput: currentOutput.uid)
+                            } else {
+                                audioManager.setPreferredInput(device, forOutput: currentOutput.uid)
+                            }
+                        } label: {
+                            if isPreferred {
+                                Label("Clear preferred for \(currentOutput.name)", systemImage: "star.slash")
+                            } else {
+                                Label("Prefer for \(currentOutput.name)", systemImage: "star")
+                            }
+                        }
+                    }
+
                     if isDisconnected {
                         Divider()
                         Button(role: .destructive) {

--- a/AudioPriorityBar/Views/MenuBarView.swift
+++ b/AudioPriorityBar/Views/MenuBarView.swift
@@ -214,7 +214,9 @@ struct VolumeSliderView: View {
     @EnvironmentObject var audioManager: AudioManager
 
     var volumeIcon: String {
-        if audioManager.currentMode == .headphone {
+        if audioManager.isActiveOutputMuted {
+            return "speaker.slash.fill"
+        } else if audioManager.currentMode == .headphone {
             return "headphones"
         } else {
             if audioManager.volume <= 0 {
@@ -231,11 +233,17 @@ struct VolumeSliderView: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: volumeIcon)
-                .font(.system(size: 13))
-                .foregroundColor(.accentColor)
-                .frame(width: 20)
-                .animation(.easeInOut(duration: 0.15), value: volumeIcon)
+            Button {
+                audioManager.toggleOutputMute()
+            } label: {
+                Image(systemName: volumeIcon)
+                    .font(.system(size: 13))
+                    .foregroundColor(.accentColor)
+                    .frame(width: 20)
+                    .animation(.easeInOut(duration: 0.15), value: volumeIcon)
+            }
+            .buttonStyle(.plain)
+            .help(audioManager.isActiveOutputMuted ? "Unmute" : "Mute")
 
             Slider(
                 value: Binding(

--- a/AudioPriorityBar/Views/MenuBarView.swift
+++ b/AudioPriorityBar/Views/MenuBarView.swift
@@ -96,9 +96,17 @@ struct MenuBarView: View {
                 }
 
                 Spacer()
-                
-                // Launch at login toggle
-                LaunchAtLoginToggle()
+
+                // Settings button
+                Button {
+                    PreferencesWindowController.shared.show(audioManager: audioManager)
+                } label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary.opacity(0.6))
+                }
+                .buttonStyle(.plain)
+                .help("Preferences")
 
                 // Edit mode toggle
                 Button {

--- a/AudioPriorityBar/Views/PreferencesView.swift
+++ b/AudioPriorityBar/Views/PreferencesView.swift
@@ -45,6 +45,7 @@ struct PreferencesView: View {
 /// General preferences tab
 struct GeneralPreferencesTab: View {
     @StateObject private var launchManager = LaunchAtLoginManager.shared
+    @EnvironmentObject var audioManager: AudioManager
 
     var body: some View {
         ScrollView {
@@ -66,6 +67,39 @@ struct GeneralPreferencesTab: View {
                     .padding(12)
                 } label: {
                     Label("Startup", systemImage: "power.circle")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .textCase(.uppercase)
+                }
+                .groupBoxStyle(PreferencesGroupBoxStyle())
+
+                // Quick Switch section
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Toggle(isOn: Binding(
+                            get: { audioManager.priorityManager.isQuickSwitchEnabled },
+                            set: { audioManager.priorityManager.isQuickSwitchEnabled = $0 }
+                        )) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Quick Switch Mode")
+                                    .font(.system(size: 13, weight: .medium))
+                                Text("Single-click the menu bar icon to toggle between speakers and headphones. Right-click to open the menu.")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .toggleStyle(.switch)
+                        
+                        if audioManager.priorityManager.isQuickSwitchEnabled {
+                            Text("Restart the app for this change to take effect.")
+                                .font(.system(size: 11))
+                                .foregroundColor(.orange)
+                                .padding(.top, 4)
+                        }
+                    }
+                    .padding(12)
+                } label: {
+                    Label("Menu Bar", systemImage: "hand.point.up.left.fill")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(.secondary)
                         .textCase(.uppercase)

--- a/AudioPriorityBar/Views/PreferencesView.swift
+++ b/AudioPriorityBar/Views/PreferencesView.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+/// Main preferences view with General and About tabs
+struct PreferencesView: View {
+    @EnvironmentObject var audioManager: AudioManager
+    @State private var selectedTab: PreferencesTab = .general
+
+    enum PreferencesTab: String, CaseIterable {
+        case general = "General"
+        case about = "About"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Tab picker
+            Picker("", selection: $selectedTab) {
+                ForEach(PreferencesTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 16)
+
+            Divider()
+
+            // Tab content
+            Group {
+                switch selectedTab {
+                case .general:
+                    GeneralPreferencesTab()
+                        .transition(.opacity)
+                case .about:
+                    AboutPreferencesTab()
+                        .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.15), value: selectedTab)
+        }
+        .frame(width: 480, height: 400)
+    }
+}
+
+/// General preferences tab
+struct GeneralPreferencesTab: View {
+    @StateObject private var launchManager = LaunchAtLoginManager.shared
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // Launch at Login section
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Toggle(isOn: $launchManager.isEnabled) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Launch at Login")
+                                    .font(.system(size: 13, weight: .medium))
+                                Text("Automatically start Audio Priority Bar when you log in")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .toggleStyle(.switch)
+                    }
+                    .padding(12)
+                } label: {
+                    Label("Startup", systemImage: "power.circle")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .textCase(.uppercase)
+                }
+                .groupBoxStyle(PreferencesGroupBoxStyle())
+
+                // Auto-switching section
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Auto-Switching Behavior")
+                            .font(.system(size: 13, weight: .medium))
+
+                        Text("Audio Priority Bar automatically switches between speakers and headphones based on your device priorities. Use the mode toggle to switch between Speaker and Headphone modes, or enable Manual mode to disable auto-switching.")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(12)
+                } label: {
+                    Label("Auto-Switching", systemImage: "arrow.left.arrow.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .textCase(.uppercase)
+                }
+                .groupBoxStyle(PreferencesGroupBoxStyle())
+
+                Spacer()
+            }
+            .padding(20)
+        }
+    }
+}
+
+/// About preferences tab
+struct AboutPreferencesTab: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // App icon and name
+                VStack(spacing: 12) {
+                    if let appIcon = NSImage(named: "AppIcon") {
+                        Image(nsImage: appIcon)
+                            .resizable()
+                            .frame(width: 80, height: 80)
+                            .cornerRadius(12)
+                    }
+
+                    Text(AppInfo.appName)
+                        .font(.system(size: 18, weight: .semibold))
+
+                    Text(AppInfo.versionString)
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                }
+                .padding(.top, 20)
+
+                Divider()
+                    .padding(.horizontal, 40)
+
+                // Description
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("About")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .textCase(.uppercase)
+
+                    Text("Audio Priority Bar is a menu bar utility for macOS that helps you quickly switch between audio devices and manage your sound output priorities.")
+                        .font(.system(size: 13))
+                        .foregroundColor(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
+                }
+                .frame(maxWidth: 400)
+                .padding(.horizontal, 20)
+
+                // GitHub link
+                VStack(spacing: 10) {
+                    Button {
+                        if let url = URL(string: "https://github.com/johanhenkens/AudioPriorityBar") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "link")
+                                .font(.system(size: 12))
+                            Text("View on GitHub")
+                                .font(.system(size: 13, weight: .medium))
+                        }
+                        .foregroundColor(.accentColor)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.accentColor.opacity(0.1))
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+            }
+            .padding(.bottom, 20)
+        }
+    }
+}
+
+/// Custom group box style matching MenuBarView design
+struct PreferencesGroupBoxStyle: GroupBoxStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            configuration.label
+                .padding(.horizontal, 4)
+
+            configuration.content
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.primary.opacity(0.04))
+        )
+    }
+}

--- a/AudioPriorityBar/Views/PreferencesView.swift
+++ b/AudioPriorityBar/Views/PreferencesView.swift
@@ -106,6 +106,37 @@ struct GeneralPreferencesTab: View {
                 }
                 .groupBoxStyle(PreferencesGroupBoxStyle())
 
+                // System Output Sync section
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Toggle(isOn: Binding(
+                            get: { audioManager.priorityManager.syncSystemOutput },
+                            set: { audioManager.priorityManager.syncSystemOutput = $0 }
+                        )) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Sync System Sound Effects Output")
+                                    .font(.system(size: 13, weight: .medium))
+                                Text("Automatically update \"Play sound effects through\" in System Settings to match the selected output device.")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .toggleStyle(.switch)
+                        
+                        Text("⚠️ If you disable this app, you may need to manually reset the system sound effects output in System Settings.")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                            .padding(.top, 4)
+                    }
+                    .padding(12)
+                } label: {
+                    Label("System Audio", systemImage: "speaker.wave.2.circle")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .textCase(.uppercase)
+                }
+                .groupBoxStyle(PreferencesGroupBoxStyle())
+
                 // Auto-switching section
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
@@ -178,7 +209,7 @@ struct AboutPreferencesTab: View {
                 // GitHub link
                 VStack(spacing: 10) {
                     Button {
-                        if let url = URL(string: "https://github.com/johanhenkens/AudioPriorityBar") {
+                        if let url = URL(string: "https://github.com/jhenkens/AudioPriorityBar") {
                             NSWorkspace.shared.open(url)
                         }
                     } label: {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="icon.png" width="128" height="128" alt="Audio Priority Bar Icon">
 </p>
 
-A native macOS menu bar app that automatically manages audio device priorities. Set your preferred order for speakers, headphones, and microphones - the app automatically switches to the highest-priority connected device.
+A native macOS menu bar app that intelligently manages your audio devices. Organize speakers, headphones, and microphones by priority, and let the app automatically switch to your preferred device when you plug it in. Perfect for users who frequently switch between multiple audio setups.
 
 ![macOS 13+](https://img.shields.io/badge/macOS-13%2B-blue)
 ![Swift](https://img.shields.io/badge/Swift-5.9-orange)
@@ -14,14 +14,28 @@ A native macOS menu bar app that automatically manages audio device priorities. 
 
 ## Features
 
-- **Priority-based auto-switching**: Devices are ranked by priority. When a higher-priority device connects, it automatically becomes active.
-- **Separate speaker/headphone modes**: Output devices are categorized as either speakers or headphones, each with their own priority list.
-- **Manual override**: Enable "Custom" mode (hand icon) to disable auto-switching and select devices freely.
-- **Device memory**: Remembers all devices you've ever connected, even when disconnected. Edit mode shows disconnected devices with "last seen" timestamps.
-- **Per-category ignore**: Hide devices from specific categories without affecting others.
+### Smart Audio Management
+- **Priority-based auto-switching**: Rank your devices by preference. When you connect a higher-priority device, it automatically becomes active - no manual switching needed.
+- **Dual-mode operation**: Separate priority lists for speakers and headphones. Switch modes manually or enable quick-switch for one-click toggling.
+- **Fast switching**: Enable quick-switch mode in preferences to toggle between speakers and headphones with a single left-click on the menu bar icon. Only switches when devices are available in the target mode.
+- **Manual mode**: Toggle "Custom" mode (✋ hand icon) to disable auto-switching and control devices manually.
+- **Persistent device memory**: Remembers every device you've connected, even when unplugged. Maintains priority order and preferences across reconnections.
+
+### Volume & Mute Controls
+- **Integrated volume control**: Adjust output volume via slider, scroll wheel, or system keys.
+- **Smart mute handling**: Click the volume icon to mute/unmute. Adjusting volume automatically unmutes if currently muted.
+- **Visual feedback**: Menu bar icon shows current mode, volume level, mute status, and microphone state.
+
+### Device Organization
 - **Drag-to-reorder**: Reorder devices by dragging or using up/down arrows.
-- **Volume control**: Adjust volume with slider or scroll wheel.
-- **Menu bar integration**: Shows current mode icon and volume percentage.
+- **Per-category customization**: Assign output devices to speaker or headphone categories. Hide devices from specific categories without affecting others.
+- **Device filtering**: Hide devices you don't use or mark them as "never use" to exclude them from auto-switching.
+- **Preferred input pairing**: Assign specific microphones to specific output devices for automatic switching.
+
+### Edit Mode & History
+- **Comprehensive edit mode**: See all devices ever connected, including disconnected ones (shown grayed out).
+- **Timestamp tracking**: View "last seen" timestamps for disconnected devices.
+- **Device management**: Forget old devices you no longer use to keep your lists clean.
 
 ## Installation
 
@@ -50,41 +64,76 @@ Check the [Releases](https://github.com/tobi/AudioPriorityBar/releases) page for
 
 ## Usage
 
-### Modes
+### Operating Modes
 
 | Mode | Icon | Behavior |
 |------|------|----------|
 | **Speakers** | 🔊 | Shows speaker devices, auto-switches to highest priority |
 | **Headphones** | 🎧 | Shows headphone devices, auto-switches to highest priority |
-| **Custom** | ✋ | Shows all devices, no auto-switching |
+| **Custom** | ✋ | Shows all devices, disables auto-switching for manual control |
 
-### Managing Priorities
+### Quick Access (Menu Bar Icon)
 
-- **Click a device**: Moves it to #1 priority (in normal mode) or just selects it (in custom mode)
-- **Drag devices**: Reorder by dragging the handle
-- **Up/Down arrows**: Fine-tune order on hover
+- **Left-click**: Open main menu (default) or toggle speaker/headphone mode (if quick-switch enabled in preferences)
+- **Right-click**: Always opens main menu when quick-switch is enabled
+- **Icon display**: Shows current mode icon, volume level, mute status (🔇), and microphone mute indicator
 
-### Device Actions (hover menu)
+### Volume & Mute
 
-- **Move to Speakers/Headphones**: Change device category
-- **Ignore as [category]**: Hide from current category only
-- **Ignore entirely**: Hide from both speaker and headphone lists
-- **Forget Device**: Remove disconnected device from memory
+- **Volume slider**: Drag to adjust output volume
+- **Scroll wheel**: Hover over volume slider and scroll to adjust
+- **Volume icon**: Click to toggle mute/unmute
+- **Smart unmute**: Adjusting volume when muted automatically unmutes
+
+### Managing Device Priorities
+
+- **Click a device**: Makes it active and moves it to #1 priority (in auto-switch modes) or just selects it (in custom mode)
+- **Drag to reorder**: Grab the handle (≡) and drag devices up/down
+- **Arrow controls**: Hover over a device to reveal up/down arrows for fine-tuning order
+- **Reordering behavior**: In speaker/headphone modes, moving a device to #1 automatically activates it
+
+### Device Actions (Edit Mode Menu)
+
+- **Move to Speakers/Headphones**: Re-categorize output devices
+- **Ignore as [category]**: Hide device from current category only
+- **Ignore entirely**: Hide from both speaker and headphone categories
+- **Never use**: Exclude device from auto-switching but keep it visible
+- **Set preferred input**: Pair a specific microphone with an output device
+- **Forget device**: Remove disconnected device from app memory
 
 ### Edit Mode
 
-Click "Edit" in the footer to:
-- See all devices ever connected (disconnected ones grayed out)
-- Reorder disconnected devices in the priority list
-- View "last seen" timestamps
+Click **Edit** in the footer to access advanced features:
+- View all devices ever connected, including disconnected ones (grayed out with timestamps)
+- Reorder disconnected devices to set their priority for when they reconnect
+- Manage hidden/ignored devices
 - Forget old devices you no longer use
+- Click **Done** to return to normal view
+
+### Preferences
+
+Click the **⚙️ gear icon** in the footer to access preferences:
+
+**Startup**
+- **Launch at Login**: Automatically start Audio Priority Bar when you log in to macOS
+
+**Menu Bar**
+- **Quick Switch Mode**: Enable single-click toggle between speakers/headphones (requires app restart)
+
+**System Audio**
+- **Sync System Sound Effects Output**: Automatically update macOS system sound effects output to match selected device
+
+**Auto-Switching**
+- View information about auto-switching behavior and mode controls
 
 ## How It Works
 
-1. **Device Discovery**: Uses CoreAudio to enumerate audio devices and listen for changes.
-2. **Priority Storage**: Device priorities are stored in UserDefaults, keyed by device UID (stable across reconnects).
-3. **Auto-Switching**: When devices connect/disconnect, the app automatically selects the highest-priority available device for the current mode.
-4. **Categories**: Each output device is assigned to either "speaker" or "headphone" category, with separate priority lists.
+1. **Device Discovery**: Uses CoreAudio to enumerate audio devices and listen for hardware changes in real-time.
+2. **Priority Storage**: Device priorities, categories, and preferences are stored in UserDefaults, keyed by device UID (stable across reconnects).
+3. **Smart Auto-Switching**: When devices connect/disconnect, the app automatically selects the highest-priority available device for the current mode, while avoiding switching loops.
+4. **Category System**: Each output device is assigned to either "speaker" or "headphone" category, each with independent priority lists and visibility settings.
+5. **Mute & Volume Management**: Volume and mute state are managed through CoreAudio's VirtualMainVolume property. The app automatically unmutes when volume is adjusted and prevents fast-switching to unavailable device categories.
+6. **Preferred Input Pairing**: Output devices can be paired with specific input devices for automatic microphone switching based on audio output.
 
 ## Project Structure
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+DEPLOY=false
+for arg in "$@"; do
+  if [ "$arg" = "-deploy" ]; then
+    DEPLOY=true
+  fi
+done
+
 echo "Building AudioPriorityBar..."
 
 xcodebuild -scheme AudioPriorityBar \
@@ -19,3 +26,17 @@ cp -R .build/Build/Products/Release/AudioPriorityBar.app dist/
 
 echo ""
 echo "Build complete: dist/AudioPriorityBar.app"
+
+if [ "$DEPLOY" = true ]; then
+  echo ""
+  echo "Deploying to /Applications..."
+
+  pkill -x AudioPriorityBar 2>/dev/null || true
+
+  rm -rf /Applications/AudioPriorityBar.app
+  cp -R dist/AudioPriorityBar.app /Applications/
+
+  open /Applications/AudioPriorityBar.app
+
+  echo "Deployed and launched: /Applications/AudioPriorityBar.app"
+fi


### PR DESCRIPTION
Bunch of commits - I can break them out if you like some but not all.

1) Add a preferences window that contains the start-at-login setting intitially
2) Fix the icon switching back to how it was in the releases - Headphone/Speaker Icon.
3) Add the ability to assign an input device as a priority device for a given output device. This way you can prefer your webcam microphone, unless you are using your headphones, then prefer the headphone microphone.
4) Add one-click fast switching as an option in the preferences pane. It requires a restart, but makes left click toggle between Headphone and Speakers, and right click bring up the dialog
5) Add, with a preference, the System Default Output to be switched alongside the Default Output. This wasn't being switched before, and it seems when interacting via these APIs, OSX won't follow it like it does when you interact with their built in solutions.