### PR TITLE
macOS 26 fixes, Auto mode, per-tab visibility, split Never Use, notarized build script

### DIFF
--- a/AudioPriorityBar.xcodeproj/project.pbxproj
+++ b/AudioPriorityBar.xcodeproj/project.pbxproj
@@ -17,7 +17,18 @@
 		A10000000000000000000009 /* Headphones.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000009 /* Headphones.swift */; };
 		A10000000000000000000010 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* CoreAudio.framework */; };
 		A10000000000000000000020 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000020 /* Assets.xcassets */; };
+		A10000000000000000000030 /* PriorityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000030 /* PriorityManagerTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		C20000000000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A90000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A60000000000000000000001;
+			remoteInfo = AudioPriorityBar;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		A20000000000000000000001 /* AudioPriorityBarApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPriorityBarApp.swift; sourceTree = "<group>"; };
@@ -31,7 +42,9 @@
 		A20000000000000000000009 /* Headphones.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Headphones.swift; sourceTree = "<group>"; };
 		A20000000000000000000010 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		A20000000000000000000020 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A20000000000000000000030 /* PriorityManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriorityManagerTests.swift; sourceTree = "<group>"; };
 		A30000000000000000000001 /* AudioPriorityBar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AudioPriorityBar.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A30000000000000000000002 /* AudioPriorityBarTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AudioPriorityBarTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -43,6 +56,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A40000000000000000000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -50,6 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				A50000000000000000000002 /* AudioPriorityBar */,
+				A50000000000000000000008 /* AudioPriorityBarTests */,
 				A50000000000000000000007 /* Frameworks */,
 				A50000000000000000000006 /* Products */,
 			);
@@ -100,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				A30000000000000000000001 /* AudioPriorityBar.app */,
+				A30000000000000000000002 /* AudioPriorityBarTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -112,18 +134,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-/* End PBXGroup section */
-
-/* Begin PBXResourcesBuildPhase section */
-		A40000000000000000000002 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A10000000000000000000020 /* Assets.xcassets in Resources */,
+		A50000000000000000000008 /* AudioPriorityBarTests */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000030 /* PriorityManagerTests.swift */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			path = AudioPriorityBarTests;
+			sourceTree = "<group>";
 		};
-/* End PBXResourcesBuildPhase section */
+/* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
 		A60000000000000000000001 /* AudioPriorityBar */ = {
@@ -143,6 +162,23 @@
 			productReference = A30000000000000000000001 /* AudioPriorityBar.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A60000000000000000000002 /* AudioPriorityBarTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A80000000000000000000003 /* Build configuration list for PBXNativeTarget "AudioPriorityBarTests" */;
+			buildPhases = (
+				A70000000000000000000002 /* Sources */,
+				A40000000000000000000003 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C10000000000000000000001 /* PBXTargetDependency */,
+			);
+			name = AudioPriorityBarTests;
+			productName = AudioPriorityBarTests;
+			productReference = A30000000000000000000002 /* AudioPriorityBarTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -155,6 +191,10 @@
 				TargetAttributes = {
 					A60000000000000000000001 = {
 						CreatedOnToolsVersion = 15.0;
+					};
+					A60000000000000000000002 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = A60000000000000000000001;
 					};
 				};
 			};
@@ -172,9 +212,21 @@
 			projectRoot = "";
 			targets = (
 				A60000000000000000000001 /* AudioPriorityBar */,
+				A60000000000000000000002 /* AudioPriorityBarTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A40000000000000000000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000020 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A70000000000000000000001 /* Sources */ = {
@@ -192,7 +244,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A70000000000000000000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000030 /* PriorityManagerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		C10000000000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A60000000000000000000001 /* AudioPriorityBar */;
+			targetProxy = C20000000000000000000001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		B10000000000000000000001 /* Debug */ = {
@@ -371,6 +439,44 @@
 			};
 			name = Release;
 		};
+		B30000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.audioprioritybar.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AudioPriorityBar.app/Contents/MacOS/AudioPriorityBar";
+			};
+			name = Debug;
+		};
+		B30000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.audioprioritybar.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AudioPriorityBar.app/Contents/MacOS/AudioPriorityBar";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -388,6 +494,15 @@
 			buildConfigurations = (
 				B10000000000000000000001 /* Debug */,
 				B10000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A80000000000000000000003 /* Build configuration list for PBXNativeTarget "AudioPriorityBarTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B30000000000000000000001 /* Debug */,
+				B30000000000000000000002 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AudioPriorityBar.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/AudioPriorityBar.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/AudioPriorityBar/AudioPriorityBarApp.swift
+++ b/AudioPriorityBar/AudioPriorityBarApp.swift
@@ -74,6 +74,7 @@ class AudioManager: ObservableObject {
     @Published var inputDevices: [AudioDevice] = []
     @Published var speakerDevices: [AudioDevice] = []
     @Published var headphoneDevices: [AudioDevice] = []
+    @Published var combinedDevices: [AudioDevice] = []
     @Published var hiddenInputDevices: [AudioDevice] = []
     @Published var hiddenSpeakerDevices: [AudioDevice] = []
     @Published var hiddenHeadphoneDevices: [AudioDevice] = []
@@ -83,6 +84,12 @@ class AudioManager: ObservableObject {
     @Published var volume: Float = 0
     @Published var isEditMode: Bool = false
     @Published var isCustomMode: Bool = false
+    @Published var showSpeakersTab: Bool = true
+    @Published var showHeadphonesTab: Bool = true
+    @Published var showAutoTab: Bool = true
+    @Published var showManualTab: Bool = true
+    @Published var showMicrophones: Bool = true
+    @Published var linkNeverUse: Bool = false
     @Published var mutedDeviceIds: Set<AudioObjectID> = []
     @Published var isActiveOutputMuted: Bool = false
     @Published var isActiveInputMuted: Bool = false
@@ -92,6 +99,7 @@ class AudioManager: ObservableObject {
     private var micFlashTimer: Timer?
     let priorityManager = PriorityManager()
     private var connectedDeviceUIDs: Set<String> = []
+    private var isHandlingDeviceChange = false
 
     var menuBarIcon: String {
         currentMode.icon
@@ -151,16 +159,37 @@ class AudioManager: ObservableObject {
         deviceService.setOutputVolume(newVolume)
     }
 
+    var visibleModeTabs: [OutputCategory] {
+        OutputCategory.displayModes.filter { mode in
+            switch mode {
+            case .speaker: return showSpeakersTab
+            case .headphone: return showHeadphonesTab
+            case .combined: return showAutoTab
+            }
+        }
+    }
+
+    var isAnyTabVisible: Bool {
+        !visibleModeTabs.isEmpty || showManualTab
+    }
+
     var activeOutputDevices: [AudioDevice] {
         switch currentMode {
         case .speaker: return speakerDevices
         case .headphone: return headphoneDevices
+        case .combined: return combinedDevices
         }
     }
 
     init() {
         currentMode = priorityManager.currentMode
         isCustomMode = priorityManager.isCustomMode
+        showSpeakersTab = priorityManager.showSpeakersTab
+        showHeadphonesTab = priorityManager.showHeadphonesTab
+        showAutoTab = priorityManager.showAutoTab
+        showManualTab = priorityManager.showManualTab
+        showMicrophones = priorityManager.showMicrophones
+        linkNeverUse = priorityManager.linkNeverUse
         refreshDevices()
         previousConnectedUIDs = connectedDeviceUIDs  // Initialize tracking
         refreshVolume()
@@ -192,6 +221,7 @@ class AudioManager: ObservableObject {
         for device in allConnectedDevices {
             priorityManager.rememberDevice(device.uid, name: device.name, isInput: device.type == .input)
         }
+        priorityManager.consolidateDuplicates(connectedUIDs: connectedDeviceUIDs)
         let connectedInputs = allConnectedDevices.filter { $0.type == .input }
         let connectedOutputs = allConnectedDevices.filter { $0.type == .output }
 
@@ -215,6 +245,7 @@ class AudioManager: ObservableObject {
             let headphones = allOutputs.filter { priorityManager.getCategory(for: $0) == .headphone }
             speakerDevices = priorityManager.sortByPriority(speakers, category: .speaker)
             headphoneDevices = priorityManager.sortByPriority(headphones, category: .headphone)
+            combinedDevices = priorityManager.sortByPriority(allOutputs, category: .combined)
             hiddenSpeakerDevices = []
             hiddenHeadphoneDevices = []
         } else {
@@ -237,6 +268,11 @@ class AudioManager: ObservableObject {
             let neverUseHeadphones = headphones.filter { priorityManager.isNeverUse($0) }
             speakerDevices = priorityManager.sortByPriority(visibleSpeakers, category: .speaker)
             headphoneDevices = priorityManager.sortByPriority(visibleHeadphones, category: .headphone)
+            // Combined view: all non-never-use outputs in one list. Per-category
+            // hide flags don't apply here — combined mode is the user's escape
+            // from category split, so it shouldn't inherit category-specific hides.
+            let visibleCombined = connectedOutputs.filter { !priorityManager.isNeverUse($0) }
+            combinedDevices = priorityManager.sortByPriority(visibleCombined, category: .combined)
             hiddenSpeakerDevices = regularHiddenSpeakers + neverUseSpeakers
             hiddenHeadphoneDevices = regularHiddenHeadphones + neverUseHeadphones
         }
@@ -377,6 +413,45 @@ class AudioManager: ObservableObject {
         }
     }
 
+    func moveCombinedDevice(from source: IndexSet, to destination: Int) {
+        combinedDevices.move(fromOffsets: source, toOffset: destination)
+        priorityManager.savePriorities(combinedDevices, category: .combined)
+        // In combined mode, switch to the top connected output
+        if currentMode == .combined, let top = combinedDevices.first, top.isConnected {
+            applyOutputDevice(top)
+        }
+    }
+
+    func setShowSpeakersTab(_ show: Bool) {
+        showSpeakersTab = show
+        priorityManager.showSpeakersTab = show
+    }
+
+    func setShowHeadphonesTab(_ show: Bool) {
+        showHeadphonesTab = show
+        priorityManager.showHeadphonesTab = show
+    }
+
+    func setShowAutoTab(_ show: Bool) {
+        showAutoTab = show
+        priorityManager.showAutoTab = show
+    }
+
+    func setShowManualTab(_ show: Bool) {
+        showManualTab = show
+        priorityManager.showManualTab = show
+    }
+
+    func setShowMicrophones(_ show: Bool) {
+        showMicrophones = show
+        priorityManager.showMicrophones = show
+    }
+
+    func setLinkNeverUse(_ link: Bool) {
+        linkNeverUse = link
+        priorityManager.linkNeverUse = link
+    }
+
     func setInputDevice(_ device: AudioDevice) {
         applyInputDevice(device)
     }
@@ -386,11 +461,13 @@ class AudioManager: ObservableObject {
     }
 
     private func applyInputDevice(_ device: AudioDevice) {
+        guard device.id != currentInputId else { return }
         deviceService.setDefaultDevice(device.id, type: .input)
         currentInputId = device.id
     }
 
     private func applyOutputDevice(_ device: AudioDevice) {
+        guard device.id != currentOutputId else { return }
         deviceService.setDefaultDevice(device.id, type: .output)
         currentOutputId = device.id
     }
@@ -415,18 +492,37 @@ class AudioManager: ObservableObject {
                 self?.handleDeviceChange()
             }
         }
+        deviceService.onDefaultDeviceChanged = { [weak self] in
+            Task { @MainActor in
+                self?.handleDefaultDeviceChange()
+            }
+        }
         deviceService.startListening()
     }
 
+    private func handleDefaultDeviceChange() {
+        currentInputId = deviceService.getCurrentDefaultDevice(type: .input)
+        currentOutputId = deviceService.getCurrentDefaultDevice(type: .output)
+        refreshVolume()
+        refreshMuteStatus()
+        if !isCustomMode {
+            applyHighestPriorityInput()
+        }
+    }
+
     private func handleDeviceChange() {
+        guard !isHandlingDeviceChange else { return }
+        isHandlingDeviceChange = true
+        defer { isHandlingDeviceChange = false }
+
         let oldConnectedUIDs = previousConnectedUIDs
         refreshDevices()
         refreshMuteStatus()
-        
+
         // Detect newly connected devices
         let newlyConnectedUIDs = connectedDeviceUIDs.subtracting(oldConnectedUIDs)
         previousConnectedUIDs = connectedDeviceUIDs
-        
+
         if !isCustomMode {
             // Auto-switch mode only when a new headphone connects or all headphones disconnect
             autoSwitchModeIfNeeded(newlyConnectedUIDs: newlyConnectedUIDs)
@@ -439,14 +535,18 @@ class AudioManager: ObservableObject {
     /// Only triggers on:
     /// 1. A new headphone device connects → switch to headphone mode
     /// 2. All headphones disconnect → switch to speaker mode
+    /// In combined mode, the user has explicitly opted out of category-based
+    /// auto-switching, so we don't change their mode.
     private func autoSwitchModeIfNeeded(newlyConnectedUIDs: Set<String>) {
+        guard currentMode != .combined else { return }
+
         let connectedHeadphones = headphoneDevices.filter { $0.isConnected }
         let hasConnectedHeadphones = !connectedHeadphones.isEmpty
         let hasConnectedSpeakers = speakerDevices.contains { $0.isConnected }
-        
+
         // Check if a new headphone just connected
         let newHeadphoneConnected = connectedHeadphones.contains { newlyConnectedUIDs.contains($0.uid) }
-        
+
         if newHeadphoneConnected && currentMode != .headphone {
             // A new headphone just connected - switch to headphone mode
             currentMode = .headphone

--- a/AudioPriorityBar/Models/AudioDevice.swift
+++ b/AudioPriorityBar/Models/AudioDevice.swift
@@ -9,11 +9,22 @@ enum AudioDeviceType: String, Codable {
 enum OutputCategory: String, Codable, CaseIterable {
     case speaker
     case headphone
+    /// Display-only "mode" that shows all outputs in one combined priority list.
+    /// Never used as a device category — devices are always categorized as
+    /// .speaker or .headphone for the per-category lists.
+    case combined
+
+    /// The valid categories a device can be assigned to.
+    static var deviceCategories: [OutputCategory] { [.speaker, .headphone] }
+
+    /// The selectable display modes shown in the mode toggle bar.
+    static var displayModes: [OutputCategory] { [.speaker, .headphone, .combined] }
 
     var icon: String {
         switch self {
         case .speaker: return "speaker.wave.2.fill"
         case .headphone: return "headphones"
+        case .combined: return "rectangle.stack.fill"
         }
     }
 
@@ -21,6 +32,7 @@ enum OutputCategory: String, Codable, CaseIterable {
         switch self {
         case .speaker: return "Speakers"
         case .headphone: return "Headphones"
+        case .combined: return "Auto"
         }
     }
 }

--- a/AudioPriorityBar/Services/AudioDeviceService.swift
+++ b/AudioPriorityBar/Services/AudioDeviceService.swift
@@ -4,9 +4,11 @@ import AudioToolbox
 
 class AudioDeviceService {
     var onDevicesChanged: (() -> Void)?
+    var onDefaultDeviceChanged: (() -> Void)?
     var onMuteOrVolumeChanged: (() -> Void)?
 
     private var listenerBlock: AudioObjectPropertyListenerBlock?
+    private var defaultDeviceListenerBlock: AudioObjectPropertyListenerBlock?
     private var muteVolumeListenerBlock: AudioObjectPropertyListenerBlock?
     private var monitoredDeviceIds: Set<AudioObjectID> = []
 
@@ -237,7 +239,6 @@ class AudioDeviceService {
 
         listenerBlock = { [weak self] _, _ in
             self?.onDevicesChanged?()
-            // Re-register mute/volume listeners when devices change
             self?.updateMuteVolumeListeners()
         }
 
@@ -248,7 +249,10 @@ class AudioDeviceService {
             listenerBlock!
         )
 
-        // Also listen to default device changes
+        defaultDeviceListenerBlock = { [weak self] _, _ in
+            self?.onDefaultDeviceChanged?()
+        }
+
         var inputDefaultAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultInputDevice,
             mScope: kAudioObjectPropertyScopeGlobal,
@@ -258,7 +262,7 @@ class AudioDeviceService {
             AudioObjectID(kAudioObjectSystemObject),
             &inputDefaultAddress,
             DispatchQueue.main,
-            listenerBlock!
+            defaultDeviceListenerBlock!
         )
 
         var outputDefaultAddress = AudioObjectPropertyAddress(
@@ -270,7 +274,7 @@ class AudioDeviceService {
             AudioObjectID(kAudioObjectSystemObject),
             &outputDefaultAddress,
             DispatchQueue.main,
-            listenerBlock!
+            defaultDeviceListenerBlock!
         )
 
         // Initial setup of mute/volume listeners
@@ -386,50 +390,49 @@ class AudioDeviceService {
     }
 
     func stopListening() {
-        // Remove mute/volume listeners first
         removeMuteVolumeListeners()
 
-        guard let block = listenerBlock else { return }
+        if let block = listenerBlock {
+            var propertyAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDevices,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &propertyAddress,
+                DispatchQueue.main,
+                block
+            )
+            listenerBlock = nil
+        }
 
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
+        if let block = defaultDeviceListenerBlock {
+            var inputDefaultAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &inputDefaultAddress,
+                DispatchQueue.main,
+                block
+            )
 
-        AudioObjectRemovePropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            DispatchQueue.main,
-            block
-        )
-
-        // Also remove default device change listeners
-        var inputDefaultAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        AudioObjectRemovePropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &inputDefaultAddress,
-            DispatchQueue.main,
-            block
-        )
-
-        var outputDefaultAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        AudioObjectRemovePropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &outputDefaultAddress,
-            DispatchQueue.main,
-            block
-        )
-
-        listenerBlock = nil
+            var outputDefaultAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &outputDefaultAddress,
+                DispatchQueue.main,
+                block
+            )
+            defaultDeviceListenerBlock = nil
+        }
     }
 
     private func createDevice(id: AudioObjectID, type: AudioDeviceType) -> AudioDevice? {

--- a/AudioPriorityBar/Services/PriorityManager.swift
+++ b/AudioPriorityBar/Services/PriorityManager.swift
@@ -32,16 +32,59 @@ struct StoredDevice: Codable, Equatable {
 }
 
 class PriorityManager {
-    private let defaults = UserDefaults.standard
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        migrateLegacyNeverUseIfNeeded()
+    }
+
+    /// Pre-split storage stored a single global "neverUseDevices" list keyed by
+    /// UID. After the split into per-type lists, copy old entries into the new
+    /// input/output lists. For UIDs that match known devices, infer the type
+    /// from the known-devices store; for unknown UIDs (orphans), apply to both
+    /// to preserve the prior block.
+    private func migrateLegacyNeverUseIfNeeded() {
+        let legacyKey = "neverUseDevices"
+        guard let legacyList = defaults.array(forKey: legacyKey) as? [String], !legacyList.isEmpty else {
+            defaults.removeObject(forKey: legacyKey)
+            return
+        }
+        let known = getKnownDevices()
+        var inputList = defaults.array(forKey: neverUseInputsKey) as? [String] ?? []
+        var outputList = defaults.array(forKey: neverUseOutputsKey) as? [String] ?? []
+        for uid in legacyList {
+            let matches = known.filter { $0.uid == uid }
+            let hasKnownInput = matches.contains { $0.isInput }
+            let hasKnownOutput = matches.contains { !$0.isInput }
+            let unknown = matches.isEmpty
+            if (hasKnownInput || unknown) && !inputList.contains(uid) {
+                inputList.append(uid)
+            }
+            if (hasKnownOutput || unknown) && !outputList.contains(uid) {
+                outputList.append(uid)
+            }
+        }
+        defaults.set(inputList, forKey: neverUseInputsKey)
+        defaults.set(outputList, forKey: neverUseOutputsKey)
+        defaults.removeObject(forKey: legacyKey)
+    }
 
     private let inputPrioritiesKey = "inputPriorities"
     private let speakerPrioritiesKey = "speakerPriorities"
     private let headphonePrioritiesKey = "headphonePriorities"
+    private let combinedPrioritiesKey = "combinedPriorities"
     private let deviceCategoriesKey = "deviceCategories"
     private let currentModeKey = "currentMode"
     private let customModeKey = "customMode"
     private let hiddenDevicesKey = "hiddenDevices"
     private let knownDevicesKey = "knownDevices"
+    private let showSpeakersTabKey = "showSpeakersTab"
+    private let showHeadphonesTabKey = "showHeadphonesTab"
+    private let showAutoTabKey = "showAutoTab"
+    private let showManualTabKey = "showManualTab"
+    private let showMicrophonesKey = "showMicrophones"
+    private let linkNeverUseKey = "linkNeverUse"
 
     // MARK: - Known Devices (Persistent Memory)
 
@@ -81,6 +124,89 @@ class PriorityManager {
         }
     }
 
+    /// Some devices (notably HDMI/DisplayPort display audio like the Samsung
+    /// C34J79x) report a fresh UID every reconnect, so without this we
+    /// accumulate dozens of duplicate "known device" entries with the same
+    /// name. Group by (name, isInput); for each duplicate group, keep the one
+    /// that's currently connected (or the most recently seen if none are), and
+    /// migrate UIDs in every priority/hide/category list so the survivor
+    /// inherits the user's settings.
+    func consolidateDuplicates(connectedUIDs: Set<String>) {
+        let known = getKnownDevices()
+        var groups: [String: [StoredDevice]] = [:]
+        for device in known {
+            let key = "\(device.isInput ? "in" : "out")|\(device.name)"
+            groups[key, default: []].append(device)
+        }
+
+        var survivors: [StoredDevice] = []
+        var migrations: [(from: String, to: String)] = []
+
+        for (_, entries) in groups {
+            guard entries.count > 1 else {
+                survivors.append(contentsOf: entries)
+                continue
+            }
+            let connected = entries.filter { connectedUIDs.contains($0.uid) }
+            // Two devices with the same name both physically present is rare
+            // but possible — assume they're distinct hardware and leave alone.
+            if connected.count > 1 {
+                survivors.append(contentsOf: entries)
+                continue
+            }
+            let survivor = connected.first ?? entries.max(by: { $0.lastSeen < $1.lastSeen })!
+            survivors.append(survivor)
+            for entry in entries where entry.uid != survivor.uid {
+                migrations.append((from: entry.uid, to: survivor.uid))
+            }
+        }
+
+        guard !migrations.isEmpty else { return }
+
+        // Preserve original ordering of survivors as much as possible by
+        // re-walking the original list and keeping the first survivor seen per
+        // group key.
+        var seenSurvivorUIDs = Set(survivors.map { $0.uid })
+        var orderedSurvivors: [StoredDevice] = []
+        for device in known where seenSurvivorUIDs.contains(device.uid) {
+            orderedSurvivors.append(device)
+            seenSurvivorUIDs.remove(device.uid)
+        }
+        saveKnownDevices(orderedSurvivors)
+
+        for (from, to) in migrations {
+            migrateUID(from: from, to: to)
+        }
+    }
+
+    private func migrateUID(from oldUID: String, to newUID: String) {
+        let arrayKeys = [
+            inputPrioritiesKey, speakerPrioritiesKey, headphonePrioritiesKey,
+            combinedPrioritiesKey,
+            hiddenMicsKey, hiddenSpeakersKey, hiddenHeadphonesKey,
+            neverUseInputsKey, neverUseOutputsKey
+        ]
+        for key in arrayKeys {
+            guard var arr = defaults.array(forKey: key) as? [String] else { continue }
+            if arr.contains(newUID) {
+                arr.removeAll { $0 == oldUID }
+            } else if let idx = arr.firstIndex(of: oldUID) {
+                arr[idx] = newUID
+            } else {
+                continue
+            }
+            defaults.set(arr, forKey: key)
+        }
+        if var categories = defaults.dictionary(forKey: deviceCategoriesKey) as? [String: String],
+           let cat = categories[oldUID] {
+            categories.removeValue(forKey: oldUID)
+            if categories[newUID] == nil {
+                categories[newUID] = cat
+            }
+            defaults.set(categories, forKey: deviceCategoriesKey)
+        }
+    }
+
     // MARK: - Mode Management
 
     var currentMode: OutputCategory {
@@ -101,11 +227,39 @@ class PriorityManager {
         set { defaults.set(newValue, forKey: customModeKey) }
     }
 
+    // MARK: - UI Visibility Settings (default: show)
+
+    var showSpeakersTab: Bool {
+        get { defaults.object(forKey: showSpeakersTabKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: showSpeakersTabKey) }
+    }
+
+    var showHeadphonesTab: Bool {
+        get { defaults.object(forKey: showHeadphonesTabKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: showHeadphonesTabKey) }
+    }
+
+    var showAutoTab: Bool {
+        get { defaults.object(forKey: showAutoTabKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: showAutoTabKey) }
+    }
+
+    var showManualTab: Bool {
+        get { defaults.object(forKey: showManualTabKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: showManualTabKey) }
+    }
+
+    var showMicrophones: Bool {
+        get { defaults.object(forKey: showMicrophonesKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: showMicrophonesKey) }
+    }
+
     // MARK: - Device Categories
 
     func getCategory(for device: AudioDevice) -> OutputCategory {
         let categories = defaults.dictionary(forKey: deviceCategoriesKey) as? [String: String] ?? [:]
-        if let raw = categories[device.uid], let category = OutputCategory(rawValue: raw) {
+        if let raw = categories[device.uid], let category = OutputCategory(rawValue: raw),
+           OutputCategory.deviceCategories.contains(category) {
             return category
         }
         // Default headphone-like devices to headphone category
@@ -123,23 +277,45 @@ class PriorityManager {
 
     // MARK: - Never Use Devices (never auto-selected)
 
-    private let neverUseKey = "neverUseDevices"
+    private let neverUseInputsKey = "neverUseInputs"
+    private let neverUseOutputsKey = "neverUseOutputs"
+
+    /// When true, marking a device as never-use also blocks the same UID for
+    /// the opposite type (legacy behavior). When false (default), input and
+    /// output never-use are independent.
+    var linkNeverUse: Bool {
+        get { defaults.bool(forKey: linkNeverUseKey) }
+        set { defaults.set(newValue, forKey: linkNeverUseKey) }
+    }
+
+    private func neverUseKey(for type: AudioDeviceType) -> String {
+        type == .input ? neverUseInputsKey : neverUseOutputsKey
+    }
 
     func isNeverUse(_ device: AudioDevice) -> Bool {
-        let list = defaults.array(forKey: neverUseKey) as? [String] ?? []
+        let list = defaults.array(forKey: neverUseKey(for: device.type)) as? [String] ?? []
         return list.contains(device.uid)
     }
 
     func setNeverUse(_ device: AudioDevice, neverUse: Bool) {
-        var list = defaults.array(forKey: neverUseKey) as? [String] ?? []
+        applyNeverUse(uid: device.uid, type: device.type, neverUse: neverUse)
+        if linkNeverUse {
+            let other: AudioDeviceType = device.type == .input ? .output : .input
+            applyNeverUse(uid: device.uid, type: other, neverUse: neverUse)
+        }
+    }
+
+    private func applyNeverUse(uid: String, type: AudioDeviceType, neverUse: Bool) {
+        let key = neverUseKey(for: type)
+        var list = defaults.array(forKey: key) as? [String] ?? []
         if neverUse {
-            if !list.contains(device.uid) {
-                list.append(device.uid)
+            if !list.contains(uid) {
+                list.append(uid)
             }
         } else {
-            list.removeAll { $0 == device.uid }
+            list.removeAll { $0 == uid }
         }
-        defaults.set(list, forKey: neverUseKey)
+        defaults.set(list, forKey: key)
     }
 
     // MARK: - Hidden Devices (per category)
@@ -155,7 +331,9 @@ class PriorityManager {
     }
 
     func isHidden(_ device: AudioDevice, inCategory category: OutputCategory) -> Bool {
-        let key = category == .speaker ? hiddenSpeakersKey : hiddenHeadphonesKey
+        // Hidden flags only apply to per-category lists; combined view doesn't
+        // honor them.
+        guard let key = hiddenKey(forCategory: category) else { return false }
         let hidden = defaults.array(forKey: key) as? [String] ?? []
         return hidden.contains(device.uid)
     }
@@ -170,7 +348,7 @@ class PriorityManager {
     }
 
     func hideDevice(_ device: AudioDevice, inCategory category: OutputCategory) {
-        let key = category == .speaker ? hiddenSpeakersKey : hiddenHeadphonesKey
+        guard let key = hiddenKey(forCategory: category) else { return }
         var hidden = defaults.array(forKey: key) as? [String] ?? []
         if !hidden.contains(device.uid) {
             hidden.append(device.uid)
@@ -186,7 +364,7 @@ class PriorityManager {
     }
 
     func unhideDevice(_ device: AudioDevice, fromCategory category: OutputCategory) {
-        let key = category == .speaker ? hiddenSpeakersKey : hiddenHeadphonesKey
+        guard let key = hiddenKey(forCategory: category) else { return }
         var hidden = defaults.array(forKey: key) as? [String] ?? []
         hidden.removeAll { $0 == device.uid }
         defaults.set(hidden, forKey: key)
@@ -198,6 +376,14 @@ class PriorityManager {
         } else {
             let category = getCategory(for: device)
             return category == .speaker ? hiddenSpeakersKey : hiddenHeadphonesKey
+        }
+    }
+
+    private func hiddenKey(forCategory category: OutputCategory) -> String? {
+        switch category {
+        case .speaker: return hiddenSpeakersKey
+        case .headphone: return hiddenHeadphonesKey
+        case .combined: return nil
         }
     }
 
@@ -235,6 +421,8 @@ class PriorityManager {
                 return speakerPrioritiesKey
             case .headphone:
                 return headphonePrioritiesKey
+            case .combined:
+                return combinedPrioritiesKey
             }
         }
     }
@@ -250,7 +438,34 @@ class PriorityManager {
     }
 
     private func savePriorities(_ devices: [AudioDevice], key: String) {
-        let uids = devices.map { $0.uid }
-        defaults.set(uids, forKey: key)
+        // Merge new ordering into the existing saved list so that disconnected,
+        // hidden, and never-use devices keep their saved positions even when the
+        // user reorders only the subset currently visible in the menu.
+        let newOrder = devices.map { $0.uid }
+        let displayed = Set(newOrder)
+        let existing = defaults.array(forKey: key) as? [String] ?? []
+
+        var result: [String] = []
+        var newIter = newOrder.makeIterator()
+
+        for oldUID in existing {
+            if displayed.contains(oldUID) {
+                if let next = newIter.next() {
+                    result.append(next)
+                }
+            } else {
+                result.append(oldUID)
+            }
+        }
+
+        // Append any new UIDs that weren't in the existing saved list (e.g.
+        // first time we've seen this device).
+        while let next = newIter.next() {
+            if !result.contains(next) {
+                result.append(next)
+            }
+        }
+
+        defaults.set(result, forKey: key)
     }
 }

--- a/AudioPriorityBar/Views/DeviceListView.swift
+++ b/AudioPriorityBar/Views/DeviceListView.swift
@@ -21,7 +21,7 @@ struct DeviceListView: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            ForEach(Array(devices.enumerated()), id: \.element.id) { index, device in
+            ForEach(Array(devices.enumerated()), id: \.element.uid) { index, device in
                 DraggableDeviceRow(
                     device: device,
                     index: index,

--- a/AudioPriorityBar/Views/MenuBarView.swift
+++ b/AudioPriorityBar/Views/MenuBarView.swift
@@ -9,7 +9,9 @@ struct MenuBarView: View {
         VStack(spacing: 0) {
             // Header with mode toggle and volume
             VStack(spacing: 14) {
-                ModeToggleView()
+                if audioManager.isAnyTabVisible {
+                    ModeToggleView()
+                }
                 VolumeSliderView()
             }
             .padding(.horizontal, 16)
@@ -21,63 +23,84 @@ struct MenuBarView: View {
 
             ScrollView {
                 VStack(spacing: 20) {
-                    // Speakers (show in speaker mode or custom mode)
-                    if audioManager.currentMode == .speaker || audioManager.isCustomMode {
+                    // Combined output list (Auto mode) — single list, no category split
+                    if audioManager.currentMode == .combined && !audioManager.isCustomMode {
                         DeviceSectionView(
-                            title: "Speakers",
-                            icon: "speaker.wave.2.fill",
-                            devices: audioManager.speakerDevices,
+                            title: "Outputs",
+                            icon: "rectangle.stack.fill",
+                            devices: audioManager.combinedDevices,
                             currentDeviceId: audioManager.currentOutputId,
-                            onMove: audioManager.moveSpeakerDevice,
+                            onMove: audioManager.moveCombinedDevice,
                             onSelect: { device in
-                                if !audioManager.isCustomMode {
-                                    audioManager.setMode(.speaker)
-                                }
                                 audioManager.setOutputDevice(device)
                             },
-                            onHide: { audioManager.hideDevice($0, category: .speaker) },
-                            onUnhide: { audioManager.unhideDevice($0, category: .speaker) },
-                            category: .speaker,
+                            onHide: nil,
+                            onUnhide: nil,
+                            category: .combined,
                             showCategoryPicker: true,
-                            isActiveCategory: audioManager.currentMode == .speaker || audioManager.isCustomMode
+                            isActiveCategory: true
                         )
+                    } else {
+                        // Speakers (show in speaker mode or custom mode)
+                        if audioManager.currentMode == .speaker || audioManager.isCustomMode {
+                            DeviceSectionView(
+                                title: "Speakers",
+                                icon: "speaker.wave.2.fill",
+                                devices: audioManager.speakerDevices,
+                                currentDeviceId: audioManager.currentOutputId,
+                                onMove: audioManager.moveSpeakerDevice,
+                                onSelect: { device in
+                                    if !audioManager.isCustomMode {
+                                        audioManager.setMode(.speaker)
+                                    }
+                                    audioManager.setOutputDevice(device)
+                                },
+                                onHide: { audioManager.hideDevice($0, category: .speaker) },
+                                onUnhide: { audioManager.unhideDevice($0, category: .speaker) },
+                                category: .speaker,
+                                showCategoryPicker: true,
+                                isActiveCategory: audioManager.currentMode == .speaker || audioManager.isCustomMode
+                            )
+                        }
+
+                        // Headphones (show in headphone mode or custom mode)
+                        if audioManager.currentMode == .headphone || audioManager.isCustomMode {
+                            DeviceSectionView(
+                                title: "Headphones",
+                                icon: "headphones",
+                                devices: audioManager.headphoneDevices,
+                                currentDeviceId: audioManager.currentOutputId,
+                                onMove: audioManager.moveHeadphoneDevice,
+                                onSelect: { device in
+                                    if !audioManager.isCustomMode {
+                                        audioManager.setMode(.headphone)
+                                    }
+                                    audioManager.setOutputDevice(device)
+                                },
+                                onHide: { audioManager.hideDevice($0, category: .headphone) },
+                                onUnhide: { audioManager.unhideDevice($0, category: .headphone) },
+                                category: .headphone,
+                                showCategoryPicker: true,
+                                isActiveCategory: audioManager.currentMode == .headphone || audioManager.isCustomMode
+                            )
+                        }
                     }
 
-                    // Headphones (show in headphone mode or custom mode)
-                    if audioManager.currentMode == .headphone || audioManager.isCustomMode {
+                    // Microphones
+                    if audioManager.showMicrophones {
                         DeviceSectionView(
-                            title: "Headphones",
-                            icon: "headphones",
-                            devices: audioManager.headphoneDevices,
-                            currentDeviceId: audioManager.currentOutputId,
-                            onMove: audioManager.moveHeadphoneDevice,
-                            onSelect: { device in
-                                if !audioManager.isCustomMode {
-                                    audioManager.setMode(.headphone)
-                                }
-                                audioManager.setOutputDevice(device)
-                            },
-                            onHide: { audioManager.hideDevice($0, category: .headphone) },
-                            onUnhide: { audioManager.unhideDevice($0, category: .headphone) },
-                            category: .headphone,
-                            showCategoryPicker: true,
-                            isActiveCategory: audioManager.currentMode == .headphone || audioManager.isCustomMode
+                            title: "Microphones",
+                            icon: "mic.fill",
+                            devices: audioManager.inputDevices,
+                            currentDeviceId: audioManager.currentInputId,
+                            onMove: audioManager.moveInputDevice,
+                            onSelect: audioManager.setInputDevice,
+                            onHide: { audioManager.hideDevice($0, category: nil) },
+                            onUnhide: { audioManager.unhideDevice($0, category: nil) },
+                            category: nil,
+                            showCategoryPicker: false
                         )
                     }
-
-                    // Microphones (always shown, at the bottom)
-                    DeviceSectionView(
-                        title: "Microphones",
-                        icon: "mic.fill",
-                        devices: audioManager.inputDevices,
-                        currentDeviceId: audioManager.currentInputId,
-                        onMove: audioManager.moveInputDevice,
-                        onSelect: audioManager.setInputDevice,
-                        onHide: { audioManager.hideDevice($0, category: nil) },
-                        onUnhide: { audioManager.unhideDevice($0, category: nil) },
-                        category: nil,
-                        showCategoryPicker: false
-                    )
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 14)
@@ -96,7 +119,10 @@ struct MenuBarView: View {
                 }
 
                 Spacer()
-                
+
+                // Settings popover
+                SettingsPopoverButton()
+
                 // Launch at login toggle
                 LaunchAtLoginToggle()
 
@@ -115,6 +141,7 @@ struct MenuBarView: View {
                     .foregroundColor(audioManager.isEditMode ? .accentColor : .secondary)
                 }
                 .buttonStyle(.plain)
+                .help(audioManager.isEditMode ? "Exit edit mode" : "Edit priority order — includes disconnected devices")
                 .animation(.easeInOut(duration: 0.2), value: audioManager.isEditMode)
 
                 // Quit button
@@ -133,72 +160,132 @@ struct MenuBarView: View {
             .animation(.easeInOut(duration: 0.2), value: audioManager.isEditMode)
         }
         .frame(width: 340)
+        .frame(maxHeight: 560)
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 
 struct ModeToggleView: View {
     @EnvironmentObject var audioManager: AudioManager
 
-    var body: some View {
-        HStack(spacing: 4) {
-            ForEach(OutputCategory.allCases, id: \.self) { mode in
-                let isSelected = audioManager.currentMode == mode && !audioManager.isCustomMode
-                Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        if audioManager.isCustomMode {
-                            audioManager.setCustomMode(false)
-                        }
-                        audioManager.setMode(mode)
-                    }
-                } label: {
-                    HStack(spacing: 5) {
-                        Image(systemName: mode.icon)
-                            .font(.system(size: 11))
-                        Text(mode.label)
-                            .font(.system(size: 12, weight: .medium))
-                            .lineLimit(1)
-                            .fixedSize(horizontal: true, vertical: false)
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .frame(maxWidth: .infinity)
-                    .contentShape(Rectangle())
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(isSelected ? Color.accentColor : Color.clear)
-                    )
-                    .foregroundColor(isSelected ? .white : .secondary)
-                }
-                .buttonStyle(.plain)
-            }
+    /// Wrap to 2 rows when the combined button count would overflow the
+    /// 340pt popup width — empirically that happens at 4 buttons.
+    private var useTwoRows: Bool {
+        let modeCount = audioManager.visibleModeTabs.count
+        let manualCount = audioManager.showManualTab ? 1 : 0
+        return modeCount + manualCount >= 4
+    }
 
-            // Custom mode toggle
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    audioManager.setCustomMode(!audioManager.isCustomMode)
+    var body: some View {
+        VStack(spacing: 6) {
+            VStack(spacing: 4) {
+                if !audioManager.visibleModeTabs.isEmpty {
+                    HStack(spacing: 4) {
+                        ForEach(audioManager.visibleModeTabs, id: \.self) { mode in
+                            modeButton(mode)
+                        }
+                        if audioManager.showManualTab && !useTwoRows {
+                            dividerLine
+                            manualButton
+                        }
+                    }
                 }
-            } label: {
-                Image(systemName: "hand.raised.fill")
-                    .font(.system(size: 12))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .contentShape(Rectangle())
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(audioManager.isCustomMode ? Color.orange : Color.clear)
-                    )
-                    .foregroundColor(audioManager.isCustomMode ? .white : .secondary)
+                if audioManager.showManualTab && (useTwoRows || audioManager.visibleModeTabs.isEmpty) {
+                    HStack(spacing: 4) {
+                        manualButton
+                    }
+                }
             }
-            .buttonStyle(.plain)
-            .help("Manual mode - disable auto-switching")
+            .padding(4)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.primary.opacity(0.05))
+            )
+
+            if audioManager.isCustomMode {
+                Text("Manual mode — priority order is ignored")
+                    .font(.system(size: 10))
+                    .foregroundColor(.orange)
+                    .transition(.opacity)
+            }
         }
-        .padding(4)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Color.primary.opacity(0.05))
-        )
         .animation(.easeInOut(duration: 0.2), value: audioManager.currentMode)
         .animation(.easeInOut(duration: 0.2), value: audioManager.isCustomMode)
+    }
+
+    private func modeButton(_ mode: OutputCategory) -> some View {
+        let isSelected = audioManager.currentMode == mode && !audioManager.isCustomMode
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                if audioManager.isCustomMode {
+                    audioManager.setCustomMode(false)
+                }
+                audioManager.setMode(mode)
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: mode.icon)
+                    .font(.system(size: 11))
+                Text(mode.label)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? Color.accentColor : Color.clear)
+            )
+            .foregroundColor(isSelected ? .white : .secondary)
+        }
+        .buttonStyle(.plain)
+        .help(modeHelp(mode))
+    }
+
+    private var manualButton: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                audioManager.setCustomMode(!audioManager.isCustomMode)
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "hand.raised.fill")
+                    .font(.system(size: 11))
+                Text("Manual")
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(audioManager.isCustomMode ? Color.orange : Color.clear)
+            )
+            .foregroundColor(audioManager.isCustomMode ? .white : .secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Manual mode — disable auto-switching. Pick devices yourself; the app won't override your choice.")
+    }
+
+    private var dividerLine: some View {
+        Rectangle()
+            .fill(Color.secondary.opacity(0.25))
+            .frame(width: 1, height: 18)
+            .padding(.horizontal, 2)
+    }
+
+    private func modeHelp(_ mode: OutputCategory) -> String {
+        switch mode {
+        case .speaker: return "Speakers — auto-pick top connected speaker"
+        case .headphone: return "Headphones — auto-pick top connected headphone"
+        case .combined: return "Auto — all outputs in one priority list, no speaker/headphone split"
+        }
     }
 }
 
@@ -437,6 +524,81 @@ struct HiddenDeviceRow: View {
                 isHovering = hovering
             }
         }
+    }
+}
+
+struct SettingsPopoverButton: View {
+    @EnvironmentObject var audioManager: AudioManager
+    @State private var isShown = false
+
+    var body: some View {
+        Button {
+            isShown.toggle()
+        } label: {
+            Image(systemName: "gearshape")
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Settings")
+        .popover(isPresented: $isShown, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Show in menu")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .textCase(.uppercase)
+                    .tracking(0.5)
+
+                tabToggle("Speakers tab", systemImage: "speaker.wave.2.fill",
+                          isOn: Binding(get: { audioManager.showSpeakersTab },
+                                        set: { audioManager.setShowSpeakersTab($0) }))
+                tabToggle("Headphones tab", systemImage: "headphones",
+                          isOn: Binding(get: { audioManager.showHeadphonesTab },
+                                        set: { audioManager.setShowHeadphonesTab($0) }))
+                tabToggle("Auto tab", systemImage: "rectangle.stack.fill",
+                          isOn: Binding(get: { audioManager.showAutoTab },
+                                        set: { audioManager.setShowAutoTab($0) }))
+                tabToggle("Manual tab", systemImage: "hand.raised.fill",
+                          isOn: Binding(get: { audioManager.showManualTab },
+                                        set: { audioManager.setShowManualTab($0) }))
+
+                Divider().padding(.vertical, 2)
+
+                tabToggle("Microphones section", systemImage: "mic.fill",
+                          isOn: Binding(get: { audioManager.showMicrophones },
+                                        set: { audioManager.setShowMicrophones($0) }))
+
+                Divider().padding(.vertical, 2)
+
+                Text("Behavior")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .textCase(.uppercase)
+                    .tracking(0.5)
+
+                tabToggle("Link 'Never Use' across input + output",
+                          systemImage: "link",
+                          isOn: Binding(get: { audioManager.linkNeverUse },
+                                        set: { audioManager.setLinkNeverUse($0) }))
+                .help("When on, marking a device as 'Never Use' blocks both its input and output. When off (default), input and output are independent — useful for headsets where you want the speaker but not the mic, or vice versa.")
+            }
+            .padding(14)
+            .frame(minWidth: 240)
+        }
+    }
+
+    private func tabToggle(_ label: String, systemImage: String, isOn: Binding<Bool>) -> some View {
+        Toggle(isOn: isOn) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .frame(width: 14)
+                Text(label)
+                    .font(.system(size: 12))
+            }
+        }
+        .toggleStyle(.checkbox)
     }
 }
 

--- a/AudioPriorityBarTests/PriorityManagerTests.swift
+++ b/AudioPriorityBarTests/PriorityManagerTests.swift
@@ -1,0 +1,271 @@
+import XCTest
+import CoreAudio
+@testable import AudioPriorityBar
+
+final class PriorityManagerTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var manager: PriorityManager!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "AudioPriorityBarTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        manager = PriorityManager(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        manager = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func device(_ uid: String, _ name: String? = nil, type: AudioDeviceType = .output, connected: Bool = true) -> AudioDevice {
+        // PriorityManager keys everything off uid; the AudioObjectID is irrelevant here.
+        AudioDevice(id: 0, uid: uid, name: name ?? uid, type: type, isConnected: connected)
+    }
+
+    private func savedPriorities(category: OutputCategory) -> [String] {
+        let key = category == .speaker ? "speakerPriorities" : "headphonePriorities"
+        return defaults.array(forKey: key) as? [String] ?? []
+    }
+
+    private func savedInputPriorities() -> [String] {
+        defaults.array(forKey: "inputPriorities") as? [String] ?? []
+    }
+
+    // MARK: - savePriorities merge behavior
+    // Bug fixed: a reorder of only the visible subset used to overwrite the
+    // entire saved list, wiping the saved positions of disconnected, hidden,
+    // and never-use devices.
+
+    func test_savePriorities_preservesDisconnectedDevicesInBetween() {
+        // Seed the saved list as if A, B, C, D had all been ordered together.
+        manager.savePriorities([device("A"), device("B"), device("C"), device("D")], category: .speaker)
+
+        // Now C is disconnected — only A, B, D are visible. User reorders to B, A, D.
+        manager.savePriorities([device("B"), device("A"), device("D")], category: .speaker)
+
+        // C must still be in the saved list, in its original slot relative to A/B/D.
+        XCTAssertEqual(savedPriorities(category: .speaker), ["B", "A", "C", "D"])
+    }
+
+    func test_savePriorities_preservesHiddenDevicesAtTheirPositions() {
+        manager.savePriorities([device("A"), device("Hidden"), device("B"), device("C")], category: .headphone)
+
+        // User hides "Hidden" then reorders the remaining visible devices.
+        manager.savePriorities([device("C"), device("A"), device("B")], category: .headphone)
+
+        XCTAssertEqual(savedPriorities(category: .headphone), ["C", "Hidden", "A", "B"])
+    }
+
+    func test_savePriorities_appendsBrandNewDeviceAtEnd() {
+        manager.savePriorities([device("A"), device("B")], category: .speaker)
+
+        // A new device E shows up alongside A and B; user keeps A, B in front.
+        manager.savePriorities([device("A"), device("B"), device("E")], category: .speaker)
+
+        XCTAssertEqual(savedPriorities(category: .speaker), ["A", "B", "E"])
+    }
+
+    func test_savePriorities_emptyExistingListBecomesNewOrder() {
+        manager.savePriorities([device("X"), device("Y"), device("Z")], category: .speaker)
+        XCTAssertEqual(savedPriorities(category: .speaker), ["X", "Y", "Z"])
+    }
+
+    func test_savePriorities_visibleReorderPreservesMultipleHiddenSlots() {
+        manager.savePriorities([device("A"), device("H1"), device("B"), device("H2"), device("C")], category: .speaker)
+
+        manager.savePriorities([device("C"), device("B"), device("A")], category: .speaker)
+
+        // Visible devices (A, B, C) take the visible slots in their new order;
+        // hidden slots stay where they were.
+        XCTAssertEqual(savedPriorities(category: .speaker), ["C", "H1", "B", "H2", "A"])
+    }
+
+    func test_savePriorities_doesNotDuplicateUIDsWhenNewDeviceAlreadyInOldList() {
+        manager.savePriorities([device("A"), device("B"), device("C")], category: .speaker)
+
+        // New visible list has same devices, just reordered.
+        manager.savePriorities([device("B"), device("C"), device("A")], category: .speaker)
+
+        let saved = savedPriorities(category: .speaker)
+        XCTAssertEqual(saved.count, Set(saved).count, "Saved list should contain no duplicate UIDs")
+        XCTAssertEqual(saved, ["B", "C", "A"])
+    }
+
+    func test_savePriorities_inputAndOutputListsAreIndependent() {
+        manager.savePriorities([device("Mic1", type: .input), device("Mic2", type: .input)], type: .input)
+        manager.savePriorities([device("Spk1"), device("Spk2")], category: .speaker)
+
+        XCTAssertEqual(savedInputPriorities(), ["Mic1", "Mic2"])
+        XCTAssertEqual(savedPriorities(category: .speaker), ["Spk1", "Spk2"])
+    }
+
+    // MARK: - consolidateDuplicates
+    // Bug fixed: HDMI/DisplayPort display audio devices report a fresh UID
+    // each reconnect, accumulating dozens of "known device" entries with the
+    // same name. consolidateDuplicates merges them by (name, isInput) and
+    // migrates the user's settings onto the surviving UID.
+
+    func test_consolidateDuplicates_collapsesDuplicateNamedDisconnectedEntries() {
+        manager.rememberDevice("uid-1", name: "C34J79x", isInput: false)
+        manager.rememberDevice("uid-2", name: "C34J79x", isInput: false)
+        manager.rememberDevice("uid-3", name: "C34J79x", isInput: false)
+        XCTAssertEqual(manager.getKnownDevices().count, 3)
+
+        // None currently connected — survivor is most recently seen (uid-3).
+        manager.consolidateDuplicates(connectedUIDs: [])
+
+        let known = manager.getKnownDevices()
+        XCTAssertEqual(known.count, 1)
+        XCTAssertEqual(known.first?.uid, "uid-3")
+        XCTAssertEqual(known.first?.name, "C34J79x")
+    }
+
+    func test_consolidateDuplicates_prefersConnectedSurvivor() {
+        manager.rememberDevice("old-1", name: "C34J79x", isInput: false)
+        manager.rememberDevice("old-2", name: "C34J79x", isInput: false)
+        // Most recently seen is "fresh" but the connected one is "old-1".
+        manager.rememberDevice("fresh", name: "C34J79x", isInput: false)
+
+        manager.consolidateDuplicates(connectedUIDs: ["old-1"])
+
+        let known = manager.getKnownDevices()
+        XCTAssertEqual(known.map { $0.uid }, ["old-1"])
+    }
+
+    func test_consolidateDuplicates_doesNotMergeDifferentNames() {
+        manager.rememberDevice("a-uid", name: "A", isInput: false)
+        manager.rememberDevice("b-uid", name: "B", isInput: false)
+
+        manager.consolidateDuplicates(connectedUIDs: [])
+
+        XCTAssertEqual(manager.getKnownDevices().count, 2)
+    }
+
+    func test_consolidateDuplicates_doesNotMergeAcrossInputOutput() {
+        manager.rememberDevice("input-uid", name: "Same Name", isInput: true)
+        manager.rememberDevice("output-uid", name: "Same Name", isInput: false)
+
+        manager.consolidateDuplicates(connectedUIDs: [])
+
+        XCTAssertEqual(manager.getKnownDevices().count, 2)
+    }
+
+    func test_consolidateDuplicates_leavesAloneWhenMultipleEntriesAreConnected() {
+        // Two distinct physically-present devices that happen to share a name
+        // — assume they're real distinct hardware and don't merge.
+        manager.rememberDevice("uid-1", name: "USB Audio", isInput: false)
+        manager.rememberDevice("uid-2", name: "USB Audio", isInput: false)
+
+        manager.consolidateDuplicates(connectedUIDs: ["uid-1", "uid-2"])
+
+        XCTAssertEqual(manager.getKnownDevices().count, 2)
+    }
+
+    func test_consolidateDuplicates_migratesPriorityListToSurvivorUID() {
+        manager.rememberDevice("old", name: "C34J79x", isInput: false)
+        manager.rememberDevice("new", name: "C34J79x", isInput: false)
+        manager.savePriorities([device("Speaker1"), device("old", "C34J79x"), device("Speaker2")], category: .speaker)
+
+        // "new" just connected with a fresh UID; "old" is gone.
+        manager.consolidateDuplicates(connectedUIDs: ["new"])
+
+        XCTAssertEqual(savedPriorities(category: .speaker), ["Speaker1", "new", "Speaker2"])
+    }
+
+    func test_consolidateDuplicates_doesNotInsertSurvivorTwiceIfAlreadyInList() {
+        // Both old and new UIDs are already in the priority list.
+        manager.rememberDevice("old", name: "C34J79x", isInput: false)
+        manager.rememberDevice("new", name: "C34J79x", isInput: false)
+        manager.savePriorities([device("old", "C34J79x"), device("new", "C34J79x"), device("Speaker1")], category: .speaker)
+
+        manager.consolidateDuplicates(connectedUIDs: ["new"])
+
+        // Survivor "new" stays at its position; "old" is removed.
+        let saved = savedPriorities(category: .speaker)
+        XCTAssertEqual(saved, ["new", "Speaker1"])
+        XCTAssertEqual(saved.count, Set(saved).count)
+    }
+
+    func test_consolidateDuplicates_migratesNeverUseFlag() {
+        manager.rememberDevice("old", name: "C34J79x", isInput: false)
+        manager.rememberDevice("new", name: "C34J79x", isInput: false)
+        manager.setNeverUse(device("old", "C34J79x"), neverUse: true)
+        XCTAssertTrue(manager.isNeverUse(device("old", "C34J79x")))
+
+        manager.consolidateDuplicates(connectedUIDs: ["new"])
+
+        XCTAssertTrue(manager.isNeverUse(device("new", "C34J79x")))
+        XCTAssertFalse(manager.isNeverUse(device("old", "C34J79x")))
+    }
+
+    func test_consolidateDuplicates_migratesCategoryAssignment() {
+        manager.rememberDevice("old", name: "C34J79x", isInput: false)
+        manager.rememberDevice("new", name: "C34J79x", isInput: false)
+        manager.setCategory(.headphone, for: device("old", "C34J79x"))
+
+        manager.consolidateDuplicates(connectedUIDs: ["new"])
+
+        XCTAssertEqual(manager.getCategory(for: device("new", "C34J79x")), .headphone)
+    }
+
+    func test_consolidateDuplicates_migratesHiddenList() {
+        manager.rememberDevice("old", name: "C34J79x", isInput: false)
+        manager.rememberDevice("new", name: "C34J79x", isInput: false)
+        manager.setCategory(.speaker, for: device("old", "C34J79x"))
+        manager.setCategory(.speaker, for: device("new", "C34J79x"))
+        manager.hideDevice(device("old", "C34J79x"), inCategory: .speaker)
+        XCTAssertTrue(manager.isHidden(device("old", "C34J79x"), inCategory: .speaker))
+
+        manager.consolidateDuplicates(connectedUIDs: ["new"])
+
+        XCTAssertTrue(manager.isHidden(device("new", "C34J79x"), inCategory: .speaker))
+    }
+
+    func test_consolidateDuplicates_isIdempotent() {
+        manager.rememberDevice("uid-1", name: "C34J79x", isInput: false)
+        manager.rememberDevice("uid-2", name: "C34J79x", isInput: false)
+
+        manager.consolidateDuplicates(connectedUIDs: [])
+        let firstPass = manager.getKnownDevices()
+        manager.consolidateDuplicates(connectedUIDs: [])
+        let secondPass = manager.getKnownDevices()
+
+        XCTAssertEqual(firstPass.count, 1)
+        XCTAssertEqual(firstPass.map { $0.uid }, secondPass.map { $0.uid })
+    }
+
+    func test_consolidateDuplicates_acrossReconnectsConvergesToOneEntry() {
+        // Simulate the real-world scenario: monitor reconnects 5 times with
+        // fresh UIDs each time; each reconnect triggers a refresh that calls
+        // rememberDevice + consolidateDuplicates.
+        for i in 1...5 {
+            let uid = "C34J79x-session-\(i)"
+            manager.rememberDevice(uid, name: "C34J79x", isInput: false)
+            manager.consolidateDuplicates(connectedUIDs: [uid])
+            XCTAssertEqual(manager.getKnownDevices().count, 1, "Should never accumulate duplicates")
+        }
+
+        XCTAssertEqual(manager.getKnownDevices().first?.uid, "C34J79x-session-5")
+    }
+
+    func test_consolidateDuplicates_preservesPriorityAcrossReconnects() {
+        // First connection: add to priority list with a manual position.
+        manager.rememberDevice("session-1", name: "C34J79x", isInput: false)
+        manager.rememberDevice("Speaker1", name: "Built-in", isInput: false)
+        manager.savePriorities([device("Speaker1"), device("session-1", "C34J79x")], category: .speaker)
+        manager.consolidateDuplicates(connectedUIDs: ["session-1", "Speaker1"])
+
+        // Reconnect with a new UID — the saved priority position should follow.
+        manager.rememberDevice("session-2", name: "C34J79x", isInput: false)
+        manager.consolidateDuplicates(connectedUIDs: ["session-2", "Speaker1"])
+
+        XCTAssertEqual(savedPriorities(category: .speaker), ["Speaker1", "session-2"])
+    }
+}

--- a/build-notarized.sh
+++ b/build-notarized.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# Build, sign, notarize, and staple AudioPriorityBar.app.
+#
+# One-time setup before this script will work:
+#
+#   1. Install a "Developer ID Application" certificate from your Apple
+#      Developer account into your login keychain.
+#        - Verify with: security find-identity -v -p codesigning
+#
+#   2. Create an app-specific password at https://appleid.apple.com and
+#      store notarytool credentials in the keychain (profile name is
+#      arbitrary — match it in NOTARY_PROFILE below):
+#        xcrun notarytool store-credentials "AudioPriorityBarNotary" \
+#          --apple-id "you@example.com" \
+#          --team-id  "YOUR_TEAM_ID" \
+#          --password "xxxx-xxxx-xxxx-xxxx"
+#
+# Env vars (all optional — auto-detected when possible):
+#
+#   SIGNING_IDENTITY   Full identity string, e.g.
+#                      "Developer ID Application: Victor Wang (ABCDE12345)".
+#                      Auto-detected if exactly one Developer ID Application
+#                      identity is in the keychain.
+#   NOTARY_PROFILE     notarytool keychain profile name.
+#                      Defaults to "AudioPriorityBarNotary".
+#   SKIP_NOTARIZE      Set to 1 to sign-only (still hardened-runtime). Useful
+#                      for iterating locally without round-tripping Apple.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+NOTARY_PROFILE="${NOTARY_PROFILE:-AudioPriorityBarNotary}"
+SKIP_NOTARIZE="${SKIP_NOTARIZE:-0}"
+
+if [ -z "${SIGNING_IDENTITY:-}" ]; then
+  matches=$(security find-identity -v -p codesigning \
+            | grep "Developer ID Application:" \
+            | sed -E 's/.*"(Developer ID Application:[^"]+)".*/\1/' || true)
+  count=$(printf '%s\n' "$matches" | grep -c . || true)
+  if [ "$count" -eq 1 ]; then
+    SIGNING_IDENTITY="$matches"
+  elif [ "$count" -eq 0 ]; then
+    echo "error: no 'Developer ID Application' identity found in keychain." >&2
+    echo "       Install one from your Apple Developer account or set SIGNING_IDENTITY." >&2
+    exit 1
+  else
+    echo "error: multiple Developer ID Application identities found:" >&2
+    printf '       %s\n' "$matches" >&2
+    echo "       Set SIGNING_IDENTITY to pick one." >&2
+    exit 1
+  fi
+fi
+
+echo "==> Signing identity: $SIGNING_IDENTITY"
+
+# Resolve Xcode if only Command Line Tools are active.
+if ! xcode-select -p 2>/dev/null | grep -q "Xcode.app"; then
+  if [ -d "/Applications/Xcode.app" ]; then
+    export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+  else
+    echo "error: Xcode.app not found; install Xcode (not just Command Line Tools)." >&2
+    exit 1
+  fi
+fi
+
+BUILD_DIR=".build"
+PRODUCT_DIR="$BUILD_DIR/Build/Products/Release"
+APP_PATH="$PRODUCT_DIR/AudioPriorityBar.app"
+DIST_DIR="dist"
+DIST_APP="$DIST_DIR/AudioPriorityBar.app"
+ZIP_PATH="$DIST_DIR/AudioPriorityBar.zip"
+
+echo "==> Building Release (arm64 + x86_64)..."
+xcodebuild -scheme AudioPriorityBar \
+  -configuration Release \
+  -derivedDataPath "$BUILD_DIR" \
+  -arch arm64 -arch x86_64 \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGN_STYLE=Manual \
+  CODE_SIGN_IDENTITY="$SIGNING_IDENTITY" \
+  OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" \
+  build \
+  | xcbeautify 2>/dev/null || xcodebuild -scheme AudioPriorityBar \
+      -configuration Release \
+      -derivedDataPath "$BUILD_DIR" \
+      -arch arm64 -arch x86_64 \
+      ONLY_ACTIVE_ARCH=NO \
+      CODE_SIGN_STYLE=Manual \
+      CODE_SIGN_IDENTITY="$SIGNING_IDENTITY" \
+      OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" \
+      build
+
+# Verify signature has the hardened runtime flag and a secure timestamp.
+echo "==> Verifying signature..."
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+codesign -dvv "$APP_PATH" 2>&1 | grep -E "Authority|TeamIdentifier|Timestamp|flags" | sed 's/^/    /'
+
+mkdir -p "$DIST_DIR"
+rm -rf "$DIST_APP"
+cp -R "$APP_PATH" "$DIST_APP"
+
+if [ "$SKIP_NOTARIZE" = "1" ]; then
+  echo "==> SKIP_NOTARIZE=1 — signed build only, not notarized."
+  echo "    $DIST_APP"
+  exit 0
+fi
+
+echo "==> Zipping for notarization..."
+rm -f "$ZIP_PATH"
+/usr/bin/ditto -c -k --keepParent "$DIST_APP" "$ZIP_PATH"
+
+echo "==> Submitting to Apple notary service (profile: $NOTARY_PROFILE)..."
+if ! xcrun notarytool submit "$ZIP_PATH" \
+      --keychain-profile "$NOTARY_PROFILE" \
+      --wait; then
+  echo "error: notarization failed. Fetch the log with:" >&2
+  echo "       xcrun notarytool log <submission-id> --keychain-profile $NOTARY_PROFILE" >&2
+  exit 1
+fi
+
+echo "==> Stapling ticket..."
+xcrun stapler staple "$DIST_APP"
+
+echo "==> Validating staple + Gatekeeper assessment..."
+xcrun stapler validate "$DIST_APP"
+spctl --assess --type execute --verbose=2 "$DIST_APP"
+
+# Refresh the zip to include the stapled ticket (handy if you distribute the zip).
+rm -f "$ZIP_PATH"
+/usr/bin/ditto -c -k --keepParent "$DIST_APP" "$ZIP_PATH"
+
+echo ""
+echo "Done: $DIST_APP"
+echo "      $ZIP_PATH"


### PR DESCRIPTION
## Summary

Two threads of work, bundled:

### macOS 26 device handling
- Fix blank MenuBarExtra popup on macOS 26.4 (`.fixedSize` on root view)
- Separate default-device-changed listener from device-list-changed listener to prevent feedback loops when the app sets the default device
- Re-entrancy guard in device-change handler to avoid cascades
- Skip redundant `setDefaultDevice` calls when device is already active
- Re-enforce input priority when macOS auto-switches mic for Bluetooth
- Consolidate duplicate device entries for HDMI/DisplayPort devices that report fresh UIDs on each reconnect
- Merge-aware `savePriorities` preserves disconnected device ordering

### UX additions
- New **Auto** output mode: combined priority list across speakers and headphones, no category split
- **Manual** mode visually distinct: text label, divider, inline caption; mode bar wraps to a second row when 4 buttons would overflow
- Settings popover with per-tab show/hide toggles (Speakers / Headphones / Auto / Manual / Microphones)
- **Never Use** split into independent input + output lists; new `linkNeverUse` setting (default off) lets a headset's mic and speaker be blocked separately. Legacy single-list entries migrate on first launch

### Tooling
- Unit test target + `PriorityManagerTests`
- Inject `UserDefaults` into `PriorityManager` for testability
- `build-notarized.sh`: signs with Developer ID + hardened runtime, submits to Apple notary service, staples ticket

## Test plan
- [ ] Existing `./build.sh` still produces a working ad-hoc-signed `.app`
- [ ] Run on macOS 26.4 — popup is no longer blank
- [ ] Connect/disconnect HDMI display audio — no duplicate entries pile up
- [ ] Toggle Manual mode — banner appears, priority enforcement stops
- [ ] Switch to Auto mode — outputs merge into one list, top connected becomes active
- [ ] Settings → hide each tab individually, verify mode bar reflows
- [ ] Mark a USB headset's mic as "Never Use" with `linkNeverUse=off` — output side still selectable
- [ ] Toggle `linkNeverUse` on — same action now blocks both
- [ ] `PriorityManagerTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)